### PR TITLE
Add Deal Desk Agent demo (03-demos/deal-desk-agent)

### DIFF
--- a/03-demos/README.md
+++ b/03-demos/README.md
@@ -6,3 +6,4 @@ End-to-end functional examples and UI-driven applications that highlight the "Be
 
 | Demo | Description |
 |---|---|
+| [`deal-desk-agent`](./deal-desk-agent) | **FSI Deal Desk Pipeline** — Multi-agent client onboarding using Claude (Opus 4.5, Sonnet 4.6, Haiku 4.5) on Vertex AI, orchestrated by Google ADK, with a Computer Use Salesforce browser agent. Built for Google Cloud NEXT 2026. See [`README`](./deal-desk-agent/README.md) and the [engineering design doc](./deal-desk-agent/DESIGN.md). |

--- a/03-demos/deal-desk-agent/.gitignore
+++ b/03-demos/deal-desk-agent/.gitignore
@@ -1,0 +1,47 @@
+# Secrets — NEVER commit
+.agent-secret
+*.secret
+*.key
+credentials.json
+service-account-*.json
+
+# Env files — commit .env.example instead
+.env
+.env.local
+.env.*.local
+agent_deploy/.env
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.venv/
+venv/
+env/
+.pytest_cache/
+.mypy_cache/
+
+# Node / frontend build
+node_modules/
+dist/
+.vite/
+*.log
+npm-debug.log*
+
+# OS / editor / AI tooling
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+.claude/
+*.swp
+*~
+
+# Cloud Build / deploy artifacts
+agent_engine_output.json
+cloudbuild-artifacts/
+
+# Misc
+*.tmp
+.cache/

--- a/03-demos/deal-desk-agent/DESIGN.md
+++ b/03-demos/deal-desk-agent/DESIGN.md
@@ -1,0 +1,522 @@
+# Deal Desk Agent — Engineering Design Document
+
+**Multi-Agent FSI Client Onboarding System**
+
+| Field | Value |
+|---|---|
+| Version | 1.1 |
+| Last updated | April 2026 |
+| Status | Production (NEXT 2026 demo) |
+| Owners | Partner Technical Architecture |
+| Audience | Engineers, SREs, security reviewers |
+
+---
+
+## Table of Contents
+
+1. [Overview and goals](#1-overview-and-goals)
+2. [System architecture](#2-system-architecture)
+3. [Data model](#3-data-model)
+4. [Agent pipeline design](#4-agent-pipeline-design)
+5. [Security and auth model](#5-security-and-auth-model)
+6. [Deployment topology](#6-deployment-topology)
+7. [Operational runbook](#7-operational-runbook)
+8. [Learnings and best practices](#8-learnings-and-best-practices)
+9. [Known limitations](#9-known-limitations)
+10. [Future work](#10-future-work)
+
+---
+
+## 1. Overview and Goals
+
+The Deal Desk Agent is a multi-agent AI system that automates FSI client onboarding end-to-end: from natural-language intake through research, compliance, risk scoring, deal package synthesis, BigQuery persistence, and live Salesforce Opportunity creation via browser automation.
+
+### 1.1 Goals
+
+- Demonstrate Claude on Vertex AI orchestrated by Google ADK in a production-realistic FSI workflow
+- Show model tiering: Opus for reasoning, Sonnet for structured tasks, Haiku for fast computation
+- Integrate Computer Use API on Vertex AI to drive a real Salesforce instance
+- Expose the agent via A2A protocol for Gemini Enterprise discovery
+- Keep operational footprint small enough to run as a booth demo
+
+### 1.2 Non-goals
+
+- Production-grade throughput (single-tenant demo system)
+- Salesforce login automation (Computer Use cannot reliably handle login/MFA flows)
+- Multi-region failover (single region `us-central1` for infra, `us-east5` for models)
+- Persistent user sessions (ephemeral `InMemorySessionService` for the ADK runner)
+
+### 1.3 Key design decisions
+
+- **Claude on Vertex AI over direct Anthropic API** — Demo objective is Anthropic + Google Cloud integration. Vertex AI provides IAM, VPC-SC, logging, billing in one place.
+- **ADK over custom orchestration** — ADK's `ParallelAgent` / `SequentialAgent` primitives map directly to the pipeline structure. Event streaming is built-in.
+- **Cloud Run for backend + frontend** — Serverless scale-to-zero between demos. 15-minute request timeout covers the full pipeline.
+- **GCE VM for browser automation** — Cloud Run cannot run persistent browser processes. GCE gives us Xvfb + Chrome + noVNC in one container.
+- **`type: "custom"` for Computer Use on Vertex** — The native `computer_20250124` tool type returns 400 on Vertex `rawPredict`; `anthropic-beta` header is rejected. Discovered via the `/test-vertex` diagnostic.
+- **Shared-secret auth for backend→VM** — Cloud Run egress IPs are dynamic — firewall IP allow-listing is not viable. App-layer shared secret is the minimum viable auth for this hop.
+
+---
+
+## 2. System Architecture
+
+### 2.1 Component diagram
+
+```
+  Browser (user)
+        |
+        | HTTPS
+        v
+  +------------------------------+
+  |  deal-desk-frontend          |    Cloud Run, us-central1
+  |  (React + Vite + Nginx)      |    Static SPA, 512MiB, 1 vCPU
+  +---------------+--------------+
+                  |
+                  | SSE (POST /api/chat, /api/run)
+                  v
+  +------------------------------+
+  |  deal-desk-backend           |    Cloud Run, us-central1
+  |  (FastAPI + ADK + httpx)     |    2GiB, 2 vCPU, 900s timeout
+  |                              |
+  |  - Conversational chat loop  |
+  |  - ADK pipeline runner       |
+  |  - A2A protocol handler      |
+  |  - Salesforce trigger proxy  |
+  +----+----------+---------+----+
+       |          |         |
+       |          |         | POST /run + X-Agent-Secret
+       v          v         v
+   Vertex AI   BigQuery   +------------------------------+
+   (us-east5) (US multi)  |  deal-desk-browser           |  GCE us-central1-a
+   Claude     clients     |  (Ubuntu 24.04 + Chrome)     |  e2-standard-4, 30GB
+   Opus 4.5   compliance  |                              |  static IP 35.223.98.125
+   Sonnet 4.6 intel       |  - Xvfb :1 (virtual display) |  tags: deal-desk-browser
+   Haiku 4.5  deals       |  - Fluxbox WM                |
+                          |  - x11vnc :5900              |
+                          |  - noVNC :6080 (fw: /32s)    |
+                          |  - agent_server :8090        |
+                          |    (fw: 0.0.0.0/0 + secret)  |
+                          |                              |
+                          |   Claude Sonnet 4.6 +        |
+                          |   Computer Use drives        |
+                          |   Chrome → Salesforce        |
+                          +------------------------------+
+                                   |
+                                   v
+                          Live Salesforce Lightning
+```
+
+### 2.2 Request lifecycle — full onboarding
+
+1. User types prompt in React UI
+2. Frontend POSTs to backend `/api/chat` (SSE response)
+3. Backend's conversational loop (Claude Sonnet) calls `run_deal_pipeline` tool
+4. Backend runs ADK pipeline: `ParallelAgent` (research + compliance) then `SequentialAgent` (risk → synthesis)
+5. Each agent streams events back through SSE: `tool_call`, `tool_result`, `agent_start`, `agent_complete`
+6. Synthesis agent writes `deal_package` row to BigQuery
+7. Backend looks up client in BigQuery and POSTs to GCE `/run` with `X-Agent-Secret` header
+8. GCE `agent_server` verifies secret, runs `salesforce_browser_agent` loop
+9. Computer Use loop: screenshot → Claude analysis → action (click/type) → repeat
+10. Agent writes `TASK_COMPLETE` when Opportunity is saved
+11. GCE streams SSE events back through Cloud Run to frontend
+12. Frontend renders browser agent events live; noVNC lets user watch in parallel
+
+---
+
+## 3. Data Model
+
+BigQuery dataset: `cpe-slarbi-nvd-ant-demos.deal_desk_agent` (US multi-region).
+
+### 3.1 Tables
+
+| Table | Key columns | Purpose |
+|---|---|---|
+| `clients` | `name, aum_millions, strategy, domicile, fee_structure, relationship_status, primary_contact, primary_contact_title, onboard_date` | Source of truth for client profiles. Read by Research; updated by Synthesis. |
+| `compliance_records` | `client_name, kyc_status, aml_status, sanctions_status, finra_registration, risk_tier, last_review_date, notes` | Read by Compliance agent. Values: `VERIFIED/CLEAR/PENDING/REVIEW/FAILED`. |
+| `market_intelligence` | `client_name, source, intel_type, summary, date, relevance_score` | SEC filings, news, hiring signals. Read by Research. |
+| `deal_packages` | `deal_id, client_name, aum_millions, strategy, mandate_type, fee_structure, compliance_status, risk_tier, risk_score, primary_contact, primary_contact_title, salesforce_opportunity_id, status, created_by, created_at, notes` | Audit trail. Written by Synthesis; stamped with SF opportunity ID by browser agent (via `update_deal_with_sf_opportunity`). |
+
+### 3.2 Query patterns
+
+All queries use BigQuery parameterized queries (`bigquery.ScalarQueryParameter`) to prevent injection. See `backend/tools/bigquery_tools.py`.
+
+```python
+sql = f"""
+    SELECT * FROM `{PROJECT_ID}.{DATASET}.clients`
+    WHERE LOWER(name) LIKE LOWER(@search_term)
+"""
+params = [bigquery.ScalarQueryParameter("search_term", "STRING", f"%{name}%")]
+```
+
+The `PROJECT_ID` and `DATASET` are injected via f-string from env vars, not user input — these are trusted configuration. Only user-supplied values flow through parameterized bindings.
+
+### 3.3 Deal state machine
+
+`deal_packages.status` transitions:
+
+```
+[INSERT] -> PENDING_SF_ENTRY
+            |
+            | update_deal_with_sf_opportunity()
+            v
+          COMPLETED
+
+Alternate paths:
+  PENDING_SF_ENTRY -> ON_HOLD     (if compliance blocker detected pre-insert)
+  PENDING_SF_ENTRY -> ESCALATED   (if risk_tier=HIGH with blockers)
+```
+
+---
+
+## 4. Agent Pipeline Design
+
+### 4.1 Model tiering
+
+| Agent | Model | Rationale |
+|---|---|---|
+| Research | Opus 4.5 | Synthesizes unstructured intel across multiple sources — reasoning-heavy |
+| Compliance | Sonnet 4.6 | Structured verification against KYC/AML/sanctions fields — precision over reasoning |
+| Risk Scoring | Haiku 4.5 | Extracts params from upstream outputs and calls a deterministic scorer — latency-sensitive |
+| Synthesis | Opus 4.5 | Assembles final deal package from three agent outputs — reasoning-heavy |
+| Salesforce Browser | Sonnet 4.6 | Visual navigation via Computer Use — Sonnet is Anthropic's recommended tier for CU |
+
+### 4.2 Pipeline topology (ADK)
+
+```python
+deal_desk_pipeline = SequentialAgent(
+    sub_agents=[
+        ParallelAgent(sub_agents=[research_agent, compliance_agent]),  # concurrent
+        SequentialAgent(sub_agents=[risk_agent, synthesis_agent]),     # serial (risk needs both parallel outputs)
+    ]
+)
+```
+
+`ParallelAgent` runs research and compliance concurrently because they are independent (both read BigQuery, neither depends on the other's output). Risk scoring depends on both parallel outputs via ADK shared state (`research_output`, `compliance_output` keys), so it runs serially after the parallel stage. Synthesis depends on `risk_output`.
+
+### 4.3 Shared state via `output_key`
+
+ADK agents communicate via named slots in session state:
+
+```
+research_agent:   output_key="research_output"
+compliance_agent: output_key="compliance_output"
+risk_agent:       output_key="risk_output"   (reads {research_output}, {compliance_output})
+synthesis_agent:  output_key="deal_package"  (reads all three)
+```
+
+### 4.4 Computer Use on Vertex AI
+
+The native `computer_20250124` tool type is **not** supported on Vertex `rawPredict`. The `anthropic-beta` header is also rejected. This was discovered by building the `/test-vertex` diagnostic endpoint that tries every combination.
+
+Working pattern: `type: "custom"` with a full JSON Schema `input_schema` enumerating all computer use actions. Display dimensions go in the tool description, not as tool fields.
+
+```python
+COMPUTER_TOOL = {
+    "type": "custom",
+    "name": "computer",
+    "description": f"Control a computer with a {W}x{H} screen... (actions and semantics)",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["click", "double_click", "type", "key",
+                                                   "scroll", "screenshot", "move", "wait"]},
+            "coordinate": {"type": "array", "items": {"type": "integer"}, "minItems": 2, "maxItems": 2},
+            "text": {"type": "string"},
+            "key": {"type": "string"},
+            # ... button, direction, amount, duration
+        },
+        "required": ["action"]
+    }
+}
+```
+
+---
+
+## 5. Security and Auth Model
+
+### 5.1 Auth layers
+
+| Hop | Transport | Auth mechanism |
+|---|---|---|
+| User → Frontend | HTTPS to Cloud Run | None (public demo) |
+| Frontend → Backend | HTTPS to Cloud Run | None (CORS allowed, `--allow-unauthenticated`) |
+| Backend → Vertex AI | HTTPS to `us-east5-aiplatform` | ADC (service account token, `roles/aiplatform.user`) |
+| Backend → BigQuery | gRPC via `google-cloud-bigquery` | ADC (`roles/bigquery.dataEditor`, `roles/bigquery.jobUser`) |
+| Backend → GCE `/run` | HTTP to static IP | Shared secret in `X-Agent-Secret` header |
+| Operator → noVNC `:6080` | HTTP/WebSocket | Firewall /32 allow-list (no app-layer auth) |
+| GCE VM → Vertex AI | HTTPS to `us-east5-aiplatform` | Instance service account (`cloud-platform` scope) |
+
+### 5.2 Shared-secret design
+
+The backend-to-VM hop is the one link where neither party is a managed Google service, so IAM-based authentication isn't directly available. We use a 32-byte hex shared secret:
+
+- Generated with `openssl rand -hex 32` (256 bits of entropy)
+- Stored on operator laptop at `~/Documents/deal-desk-agent/.agent-secret` (mode `600`)
+- Injected into GCE via `--container-env AGENT_SECRET=$(cat .agent-secret)`
+- Injected into Cloud Run via `--set-env-vars AGENT_SECRET=$(cat .agent-secret)`
+- Loaded at module import time by both backend and `agent_server`
+- Compared via `secrets.compare_digest` (constant-time, timing-attack safe)
+- Rotating: redeploy both services; backoff is manual (no atomic swap)
+
+### 5.3 Endpoint auth matrix
+
+| Endpoint | Auth | Reason |
+|---|---|---|
+| `/health` | None | GCE and uptime checks need unauthenticated probes |
+| `/run` | `X-Agent-Secret` required | Expensive operation; drives a real browser |
+| `/test-vertex` | `X-Agent-Secret` required | Leaks Vertex AI error details |
+
+### 5.4 Fail-closed behavior
+
+If `AGENT_SECRET` env var is unset at module load, the server logs a warning but does not crash (so `/health` still works). All secret-gated endpoints then return **503 "Server misconfigured"** rather than 401 — distinguishable from a bad client credential and easier to debug in logs.
+
+### 5.5 Firewall rules
+
+| Rule | Port | Source | Target tag |
+|---|---|---|---|
+| `deal-desk-browser-novnc` | 6080 | `108.48.162.9/32, 34.48.48.58/32` | `deal-desk-browser` |
+| `deal-desk-browser-agent` | 8090 | `0.0.0.0/0` | `deal-desk-browser` |
+
+Port 6080 must be restricted at the network layer because noVNC has no app-layer auth in our setup. Port 8090 is internet-reachable because Cloud Run's egress addresses are not stable — the shared secret is the gate.
+
+### 5.6 IAM inventory
+
+| Principal | Role | Purpose |
+|---|---|---|
+| `deal-desk-agent-sa` | `roles/aiplatform.user` | Invoke Claude models on Vertex AI |
+| `deal-desk-agent-sa` | `roles/bigquery.dataEditor` | Read/write tables in `deal_desk_agent` |
+| `deal-desk-agent-sa` | `roles/bigquery.jobUser` | Execute BigQuery queries |
+| GCE VM default SA | `cloud-platform` scope | Invoke Vertex AI from browser VM |
+
+---
+
+## 6. Deployment Topology
+
+### 6.1 Regions
+
+| Resource | Region | Reason |
+|---|---|---|
+| Claude models (Vertex AI) | `us-east5` | Anthropic model availability on Vertex |
+| Cloud Run (backend, frontend) | `us-central1` | Infra region; calls `us-east5` for models |
+| GCE browser VM | `us-central1-a` | Co-located with Cloud Run for low backend→VM latency |
+| BigQuery dataset | US multi-region | Default; no regulatory constraint for demo data |
+| Artifact Registry | `us-central1` | Co-located with compute |
+
+### 6.2 Container images
+
+- `us-central1-docker.pkg.dev/.../deal-desk-agent/backend:latest` — Python 3.12-slim, FastAPI, ADK, `anthropic[vertex]`
+- `us-central1-docker.pkg.dev/.../deal-desk-agent/frontend:latest` — Multi-stage Node 20 build, Nginx Alpine serve
+- `us-central1-docker.pkg.dev/.../deal-desk-agent/computer-use:latest` — Ubuntu 24.04, Xvfb, Chrome, noVNC, Python venv
+
+### 6.3 Environment variables
+
+| Variable | Backend | GCE VM | Purpose |
+|---|---|---|---|
+| `PROJECT_ID` | yes | yes | GCP project |
+| `REGION` | yes | yes | Model region (`us-east5`) |
+| `BQ_DATASET` | yes | no | BigQuery dataset name |
+| `MODEL_PROVIDER` | yes | no | `claude` or `gemini` |
+| `OPUS_MODEL` / `SONNET_MODEL` / `HAIKU_MODEL` | yes | partial (Sonnet only) | Vertex AI model strings |
+| `AGENT_SECRET` | yes | yes | Shared secret for backend↔VM |
+| `BROWSER_AGENT_URL` | yes | no | `http://<VM-IP>:8090` |
+| `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` | yes | no | ADK import-time config |
+
+### 6.4 Deploy sequence (from scratch)
+
+1. Enable APIs: `aiplatform, bigquery, run, cloudbuild, artifactregistry, compute`
+2. Create service account `deal-desk-agent-sa` with 3 roles
+3. Create Artifact Registry repo `deal-desk-agent` in `us-central1`
+4. `bq mk` dataset + `bq query` to populate 4 tables
+5. `gcloud builds submit` for all 3 containers
+6. Reserve static IP for GCE VM
+7. Create firewall rules (novnc /32-restricted, agent `0.0.0.0/0`)
+8. Generate `AGENT_SECRET`: `openssl rand -hex 32 > .agent-secret; chmod 600`
+9. `gcloud compute instances create-with-container` with `AGENT_SECRET` in `--container-env`
+10. `gcloud run deploy` backend with `AGENT_SECRET` + `BROWSER_AGENT_URL`
+11. `gcloud run deploy` frontend (no secret needed)
+12. Manually log into Salesforce via noVNC (one-time)
+
+---
+
+## 7. Operational Runbook
+
+### 7.1 Rotating `AGENT_SECRET`
+
+```bash
+# 1. Generate new secret
+openssl rand -hex 32 > ~/Documents/deal-desk-agent/.agent-secret
+
+# 2. Redeploy both services concurrently (brief mismatch window is unavoidable)
+SECRET=$(cat ~/Documents/deal-desk-agent/.agent-secret)
+
+gcloud run services update deal-desk-backend \
+    --region=us-central1 \
+    --update-env-vars="AGENT_SECRET=${SECRET}"
+
+gcloud compute instances update-container deal-desk-browser \
+    --zone=us-central1-a \
+    --container-env=AGENT_SECRET=${SECRET},PROJECT_ID=...,REGION=...,SONNET_MODEL=...
+
+# 3. Verify
+curl -X POST http://35.223.98.125:8090/run -H "X-Agent-Secret: ${SECRET}" \
+    -H "Content-Type: application/json" -d '{"deal_package":{"client_name":"Test"}}'
+```
+
+### 7.2 Rebuilding after a code change
+
+**Backend:**
+
+```bash
+cd backend/
+gcloud builds submit --tag=us-central1-docker.pkg.dev/.../backend:latest \
+    --region=us-central1 --timeout=600
+gcloud run services update deal-desk-backend --region=us-central1 \
+    --image=us-central1-docker.pkg.dev/.../backend:latest
+```
+
+**Browser VM:**
+
+```bash
+cd computer-use/
+gcloud builds submit --tag=us-central1-docker.pkg.dev/.../computer-use:latest \
+    --region=us-central1 --timeout=600
+gcloud compute instances update-container deal-desk-browser \
+    --zone=us-central1-a \
+    --container-image=us-central1-docker.pkg.dev/.../computer-use:latest \
+    --container-env=AGENT_SECRET=$(cat ~/Documents/deal-desk-agent/.agent-secret),...
+```
+
+### 7.3 Demo reset (between booth runs)
+
+The backend exposes `POST /api/reset` which: deletes `deal_packages` rows created in the last hour; resets `ACME Capital Management` to `'Returning'`; resets other prospects back to `'Prospect'`.
+
+### 7.4 Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `POST /run` → 401 | `AGENT_SECRET` mismatch | Rotate via 7.1 to resynchronize |
+| `POST /run` → 503 "Server misconfigured" | `AGENT_SECRET` env var missing on VM | Re-run `update-container` with the env var |
+| noVNC connection refused | Operator IP not in allow-list | Check `curl ifconfig.me` vs /32s in `deal-desk-browser-novnc` |
+| Chrome shows login page mid-demo | Salesforce session expired | VNC in, re-login manually |
+| Cloud Run 504 | Pipeline exceeded timeout | Verify `--timeout=900s`; check Vertex AI latency |
+| Backend import error on startup | ADK env vars unset before import | `GOOGLE_CLOUD_PROJECT`/`LOCATION` must be in `--set-env-vars` |
+| Unexpected VM behavior (elevated CPU, unfamiliar processes) | Possible unauthorized access | Stop VM; rebuild image from source; generate a new `AGENT_SECRET`; redeploy backend and VM; rotate GCP service-account keys |
+
+---
+
+## 8. Learnings and Best Practices
+
+This section captures the engineering lessons from building this system — framed as actionable guidance for anyone adapting similar patterns. Each subsection pairs **Do** (what worked / what's recommended) with **Don't** (antipatterns to avoid).
+
+### 8.1 Authentication between managed services and custom VMs
+
+**Do:**
+
+- **Use an app-layer shared secret on any custom endpoint Cloud Run (or another serverless product) must call.** Cloud Run's egress IP pool is not stable, so firewall-level source-IP allow-listing is not a viable primary control for this hop.
+- **Compare secrets with `secrets.compare_digest`** or an equivalent constant-time primitive. Timing variation from a naive `==` comparison can leak the secret byte-by-byte.
+- **Load the secret once at module import time** and keep it in a module-level variable. Re-reading from env on every request adds latency for no security benefit.
+- **Return 503 (not 401) when the secret env var is missing on the server side.** 503 means "the server is misconfigured"; 401 means "the client's credential is wrong." Conflating them makes incident triage slower.
+- **Inject the secret through platform-native mechanisms** — `--container-env` for GCE, `--set-env-vars` for Cloud Run, or Secret Manager references for production systems.
+
+**Don't:**
+
+- **Don't rely on firewall IP allow-listing alone** when the caller is a managed service with dynamic egress. The allow-list will either silently break when egress ranges rotate, or you'll be forced to open it to `0.0.0.0/0` and lose the control entirely.
+- **Don't use `==` for secret comparison.** Timing-attack safety is free when you reach for `secrets.compare_digest`; there is no reason to hand-roll this.
+- **Don't embed secrets in code, container images, or git-tracked config files.** The only acceptable locations are: platform env vars, secret managers, or operator-held files excluded by `.gitignore`.
+- **Don't log the secret value**, even at DEBUG level. A single log line persisted to Cloud Logging or a terminal scrollback is a full compromise.
+- **Don't authenticate `/health`.** GCE and most uptime-check systems cannot inject custom headers reliably, and a failing `/health` endpoint is how real outages get detected. Keep it open.
+
+### 8.2 Network posture for internet-adjacent VMs
+
+**Do:**
+
+- **Pair every exposed port with an authoritative control.** Either restrict at the network layer (firewall source ranges) OR gate at the application layer (auth header, mTLS) — pick one per port and make it explicit in the deployment config.
+- **Document which control is load-bearing for each port** in your design doc. For this system: port 6080 relies on firewall allow-listing (because noVNC has no auth in our setup); port 8090 relies on the shared secret (because Cloud Run's egress is dynamic).
+- **Use target tags on firewall rules** so rules are scoped to the specific VMs they protect, not to every instance in the VPC.
+
+**Don't:**
+
+- **Don't open a port to `0.0.0.0/0` without an app-layer authentication check in place first.** If you must open a port for operational reasons, validate the app-layer gate works (unit test, curl test) *before* relaxing the firewall.
+- **Don't combine unrelated ports in a single firewall rule** if their auth postures differ. In this system, 6080 and 8090 have different threat profiles and need different source ranges — two rules, not one.
+- **Don't assume a firewall and an auth header are redundant.** They defend against different threats: firewall stops opportunistic port scanners from spending compute on your VM; auth header stops anyone who reaches the port from triggering expensive operations.
+
+### 8.3 Fail-closed design
+
+**Do:**
+
+- **Fail closed on missing configuration.** If a required env var is absent, refuse to serve protected endpoints rather than silently degrading to "no authentication."
+- **Emit a clear warning at startup** if security-critical configuration is missing, so the problem shows up in logs immediately rather than only on the first authenticated request.
+- **Keep the unauthenticated surface minimal** — for this system, only `/health`.
+
+**Don't:**
+
+- **Don't crash the process when security config is missing.** The `/health` endpoint needs to keep working so operators can see that the VM is alive-but-misconfigured, rather than alive-and-unreachable.
+- **Don't treat "no secret configured" as "any secret accepted."** That is fail-open and is exactly the mistake that lets an ops change silently remove authentication.
+
+### 8.4 Secret lifecycle
+
+**Do:**
+
+- **Generate secrets with a CSPRNG** (`openssl rand -hex 32` is 256 bits of entropy, more than enough).
+- **Store secrets on operator machines with mode 600** and keep them out of git via `.gitignore`.
+- **Commit templates, not values.** `.env.example` with placeholder strings lets new contributors bootstrap without exposing real credentials.
+- **Rotate by redeploy.** Both the caller and callee should read the secret from env vars that can be updated via the platform's deploy tooling.
+
+**Don't:**
+
+- **Don't commit `.env` files containing real values.** Even if today's values are non-secret (project IDs, URLs), future additions will include secrets — so establish the "env files are local-only" rule early.
+- **Don't hand-edit secrets into running pods/VMs** without also updating the deployment source of truth. The next redeploy will overwrite your manual change and cause confusing outages.
+
+### 8.5 Defense in depth
+
+**Do:**
+
+- **Map every trust boundary to a control** and write it down. For this system, the audit table in §5.1 names exactly one control per hop.
+- **Accept that managed services** (BigQuery, Vertex AI) **are adequately protected by IAM alone** — you don't need to wrap them in additional auth layers. Google runs the mature access governance; adding your own is often worse than relying on theirs.
+- **Design assuming any single control will fail** — firewall rules get relaxed, secrets get leaked, IAM bindings get loosened. If the system is still safe under one-control-removed, the architecture is sound.
+
+**Don't:**
+
+- **Don't rely on obscurity** (unusual port numbers, unlisted URLs, undocumented endpoints) as a control. Port scanners find everything exposed to the public internet within hours.
+- **Don't skip the threat model.** Even a one-page "what are we protecting from whom" document catches most of the mistakes before they ship.
+
+### 8.6 Operational observability (recommended for any non-demo deployment)
+
+**Do:**
+
+- **Alert on VM CPU > 80% sustained for > 5 minutes** — unauthorized workloads (mining, spam relays, credential scanning) show up as CPU anomalies long before other signals.
+- **Track 401 counts on protected endpoints as a metric.** A spike indicates someone is probing your auth layer.
+- **Enable VPC Flow Logs** for VMs that host anything with internet exposure, and query them regularly for unexpected inbound traffic.
+- **Pin container images by SHA digest** in production manifests (`image@sha256:abc...`), not by mutable tags like `:latest`. This prevents silent image drift during pull-on-restart.
+
+**Don't:**
+
+- **Don't deploy `:latest` tags to production** — you lose the ability to reason about what code is actually running.
+- **Don't treat health-check green as evidence that auth works.** `/health` is unauthenticated by design. Test the auth path with a synthetic probe that sends a bad secret and asserts a 401 response.
+- **Don't wait until an incident to build the dashboards.** The graphs that tell you "the system is behaving normally" are the same graphs that tell you "something is wrong" — build them early.
+
+---
+
+## 9. Known Limitations
+
+- **Single-tenant** — no session isolation between concurrent users. Two simultaneous demos will collide in the Chrome profile.
+- **No Salesforce login automation** — must be done manually via noVNC at deploy time and after session expiry
+- **ADK sessions are in-memory** (`InMemorySessionService`). Restarting the backend loses all in-flight pipeline state.
+- **Secret rotation has a brief mismatch window** (Cloud Run and GCE updates are not atomic)
+- **No structured audit log** for `/run` calls — only Cloud Run request logs
+- **Frontend hardcodes the backend URL at build time**; must rebuild to point at a new backend
+- **Computer Use may click wrong coordinates** if Salesforce UI changes; no visual regression tests
+- **No rate limiting on `/run`** — a leaked secret + valid header would allow unlimited abuse
+
+---
+
+## 10. Future Work
+
+- **Secret Manager integration** — Replace env-var injection with Cloud Secret Manager references. Rotating becomes atomic; secrets never appear in deployment configs.
+- **Workload Identity for Cloud Run → GCE** — Replace shared secret with IAM-authenticated calls using Cloud Run's workload identity token, verified server-side via `google-auth`.
+- **Vertex AI Agent Engine deployment** — Move the ADK pipeline to Agent Engine for managed hosting, memory bank, and tracing. `agent_deploy/` directory has scaffolding.
+- **Gemini model swap** — `MODEL_PROVIDER=gemini` toggles all agents to Gemini 2.5 Pro/Flash/Flash-Lite. Already implemented in `deal_desk_swarm.py`; needs end-to-end test.
+- **LoopAgent for synthesis review** — Wrap `synthesis_agent` in ADK `LoopAgent` for self-critique before committing to BigQuery.
+- **MCP Toolbox integration** — Replace direct BigQuery client with MCP Toolbox for standardized tool definitions across agents.
+- **Structured audit logging** — Write every `/run` invocation to BigQuery with caller identity, timestamp, deal package, and outcome.
+- **Rate limiting** — Add per-IP rate limit on `/run` via `slowapi` or Cloud Armor.
+- **Incident response playbook** — Document procedures for responding to suspected unauthorized access: full container image rebuild from source (not just redeploy), service-account key rotation, new `AGENT_SECRET` generation, and forensic log review.

--- a/03-demos/deal-desk-agent/README.md
+++ b/03-demos/deal-desk-agent/README.md
@@ -1,0 +1,161 @@
+# Deal Desk Agent
+
+**FSI Deal Desk Pipeline — Anthropic + Google Cloud: Better Together**
+
+Built for Google Cloud NEXT 2026. A multi-agent system that automates FSI client onboarding using Claude models on Vertex AI, orchestrated by Google ADK.
+
+---
+
+> ## ⚠️ Disclaimer — Use At Your Own Risk
+>
+> This repository exists to demonstrate the **art of the possible** with Claude on Vertex AI, Google ADK, and Computer Use. It is **not production-ready software** and is **not supported**. It is single-tenant, drives a Salesforce Developer Edition sandbox, uses in-memory ADK sessions, and carries the known limitations documented in [`DESIGN.md` §9](./DESIGN.md). Sample BigQuery data is synthetic and does not represent real clients.
+>
+> **Do not deploy this against real client data, production Salesforce orgs, or regulated workloads.** If you choose to adapt any part of it, **use at your own risk** and **review it thoroughly before any deployment** — including but not limited to: IAM-based auth in place of the shared-secret pattern (see `DESIGN.md` §10), persistent session storage, rate limiting on `/run`, structured audit logging, secret rotation via a dedicated secret manager, network-layer controls such as VPC Service Controls, and a full independent security review.
+>
+> Code is provided **as-is, without warranty of any kind**, express or implied. The authors accept no liability for any damages arising from its use.
+
+---
+
+## Architecture
+
+User Prompt (React UI, Cloud Run)
+  -> FastAPI Backend (Cloud Run, us-central1)
+       |
+       +-> ParallelAgent (Research Agent [Opus 4.5] + Compliance Agent [Sonnet 4.6])
+       +-> Risk Scoring Agent [Haiku 4.5]
+       +-> Synthesis Agent [Opus 4.5]
+       |
+       +-> POST /run (X-Agent-Secret header) -> GCE Browser VM
+                                                  |
+                                                  +-> Salesforce Browser Agent [Sonnet 4.6, Computer Use]
+                                                  +-> Xvfb + Chrome + noVNC
+                                                  +-> Live Salesforce Lightning
+
+The backend-to-VM hop is authenticated by a shared secret (AGENT_SECRET) loaded
+at module import time. See Security section below.
+
+## Models
+
+| Agent | Model | Vertex AI String | Role |
+|-------|-------|-----------------|------|
+| Research | Claude Opus 4.5 | claude-opus-4-5@20251101 | Client and market intelligence |
+| Compliance | Claude Sonnet 4.6 | claude-sonnet-4-6@default | KYC/AML/sanctions checks |
+| Risk | Claude Haiku 4.5 | claude-haiku-4-5@20251001 | Quantitative risk scoring |
+| Synthesis | Claude Opus 4.5 | claude-opus-4-5@20251101 | Deal package assembly |
+| Salesforce | Claude Sonnet 4.6 | claude-sonnet-4-6@default | Browser-based CRM entry |
+
+Region: us-east5 | Project: cpe-slarbi-nvd-ant-demos
+
+## GCP Services
+
+Vertex AI, BigQuery, Cloud Run, Compute Engine, Artifact Registry, Agent Engine, ADK
+
+## Security
+
+The browser VM's agent server (port 8090) accepts requests from the public internet
+but requires a valid `X-Agent-Secret` header on `/run` and `/test-vertex`. The
+comparison uses `secrets.compare_digest` to prevent timing attacks. The `/health`
+endpoint stays unauthenticated so GCE uptime checks work.
+
+Secret management:
+- 32-byte hex secret generated with `openssl rand -hex 32`
+- Injected into the GCE container via `--container-env AGENT_SECRET=...`
+- Injected into Cloud Run via `--set-env-vars AGENT_SECRET=...`
+- Both services must carry the same value; rotating means redeploying both
+
+Firewall topology:
+- Port 6080 (noVNC) — restricted to operator laptop IPs only (no app-layer auth)
+- Port 8090 (agent API) — open to 0.0.0.0/0 (Cloud Run has dynamic egress IPs),
+  gated by `X-Agent-Secret` at the application layer
+
+Design rationale: Cloud Run egress addresses are not stable, which rules out
+firewall IP allow-listing for the backend→VM hop. The shared-secret pattern is
+the minimum viable app-layer authentication for that link. See `DESIGN.md` §5
+for the full auth model.
+
+## Project Structure
+
+deal-desk-agent/
+  backend/
+    agents/ — ADK agent definitions, computer use loop, A2A agent card
+    tools/ — BigQuery read/write tools, risk scoring engine
+    main.py — FastAPI backend with SSE streaming
+    Dockerfile, requirements.txt
+  frontend/
+    src/App.jsx — React command center UI
+    Dockerfile, package.json, vite.config.js
+  computer-use/
+    Dockerfile — Browser VM (Xvfb + Chrome + noVNC)
+    entrypoint.sh, supervisord.conf
+  deploy/
+    deploy.sh — Cloud Run deployment
+    agent_engine_deploy.py — Agent Engine deployment
+  docker-compose.yaml — Local development
+  .env — Environment config
+
+## Quick Start
+
+### Local Development
+
+  gcloud auth application-default login
+
+  # Bootstrap your environment from the templates
+  cp .env.example .env
+  cp agent_deploy/.env.example agent_deploy/.env
+  # Edit both files with your PROJECT_ID, models, Salesforce URL, etc.
+
+  # Generate the shared secret for backend↔browser VM auth
+  openssl rand -hex 32 > .agent-secret && chmod 600 .agent-secret
+
+  docker compose up --build
+
+  Frontend:  http://localhost:3000
+  Backend:   http://localhost:8080
+  noVNC:     http://localhost:6080
+
+### Deploy to GCP
+
+  cd deploy && ./deploy.sh
+
+### Deploy to Agent Engine
+
+  cd deploy && python agent_engine_deploy.py
+
+## Demo Runbook (Google NEXT Booth)
+
+### Before the Conference
+1. Deploy all services via deploy.sh
+2. Deploy browser VM on GCE
+3. Pre-authenticate Salesforce in the browser VM
+4. Test the full flow end-to-end
+5. Record a backup video of the demo
+
+### Each Demo (3-5 minutes)
+1. Click a preset scenario or type a custom prompt
+2. Narrate as agents appear in the activity feed
+3. Point out parallel execution (Research + Compliance)
+4. Highlight the deal package summary
+5. Watch the Salesforce agent drive the browser in real time
+6. Click into Salesforce to verify the Opportunity
+
+### Between Demos
+- Click Reset to clean up demo data
+- This deletes recent deal packages and resets client statuses
+
+### If Something Breaks
+- Backend down: Check Cloud Run logs
+- Browser VM frozen: SSH into GCE and restart container
+- Salesforce session expired: VNC into browser VM and re-login
+- `POST /run` returns 401: `AGENT_SECRET` mismatch between Cloud Run and GCE
+  (redeploy both with the same value from `.agent-secret`)
+- `POST /run` returns 503 "AGENT_SECRET not set": container env var missing
+  (re-run `gcloud compute instances update-container ... --container-env=AGENT_SECRET=...`)
+- Nuclear option: Play the backup video
+
+## Future Roadmap
+
+- Gemini Enterprise: Set MODEL_PROVIDER=gemini in .env to swap all agents
+- Agent Gallery: Register via Agent Engine for discovery
+- GCP Marketplace: Package as a deployable solution
+- LoopAgent: Add quality review loop around synthesis
+- MCP Toolbox: Replace direct BigQuery client with MCP

--- a/03-demos/deal-desk-agent/agent_deploy/agent.py
+++ b/03-demos/deal-desk-agent/agent_deploy/agent.py
@@ -1,0 +1,137 @@
+"""Deal Desk Agent — root agent definition for Agent Engine deployment.
+
+Conversational agent that can:
+- Answer data queries (list clients, compliance, deals)
+- Trigger the full onboarding pipeline when requested
+- Provide client deep dives
+"""
+import os
+
+# Set env vars needed by the agent
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "cpe-slarbi-nvd-ant-demos")
+os.environ["GOOGLE_CLOUD_LOCATION"] = "us-east5"
+os.environ.setdefault("PROJECT_ID", "cpe-slarbi-nvd-ant-demos")
+os.environ["REGION"] = "us-east5"
+os.environ.setdefault("BQ_DATASET", "deal_desk_agent")
+os.environ.setdefault("MODEL_PROVIDER", "claude")
+os.environ.setdefault("OPUS_MODEL", "claude-opus-4-5@20251101")
+os.environ.setdefault("SONNET_MODEL", "claude-sonnet-4-6@default")
+os.environ.setdefault("HAIKU_MODEL", "claude-haiku-4-5@20251001")
+
+from google.adk.agents import LlmAgent, SequentialAgent, ParallelAgent
+from google.adk.models.anthropic_llm import Claude
+from google.adk.models.registry import LLMRegistry
+LLMRegistry.register(Claude)
+
+from .tools import (
+    query_client_data,
+    query_market_intelligence,
+    query_compliance_records,
+    update_client_status,
+    insert_deal_package,
+    list_all_clients,
+    list_all_compliance,
+    list_deal_packages,
+    trigger_salesforce_opportunity,
+)
+from .risk_scoring import compute_risk_score
+
+OPUS = os.environ.get("OPUS_MODEL", "claude-opus-4-5@20251101")
+SONNET = os.environ.get("SONNET_MODEL", "claude-sonnet-4-6@default")
+HAIKU = os.environ.get("HAIKU_MODEL", "claude-haiku-4-5@20251001")
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PIPELINE SUB-AGENTS (for full onboarding flow)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+research_agent = LlmAgent(
+    name="research_agent",
+    model=OPUS,
+    description="Researches client background, prior relationships, and market intelligence.",
+    instruction="You are the Research Agent. Use query_client_data and query_market_intelligence to gather intelligence on the client being onboarded. Provide a structured research brief.",
+    tools=[query_client_data, query_market_intelligence],
+    output_key="research_output",
+)
+
+compliance_agent = LlmAgent(
+    name="compliance_agent",
+    model=SONNET,
+    description="Runs KYC, AML, sanctions, and FINRA compliance checks.",
+    instruction="You are the Compliance Agent. Use query_compliance_records to verify regulatory compliance. Provide clear status for each check.",
+    tools=[query_compliance_records],
+    output_key="compliance_output",
+)
+
+parallel_intake = ParallelAgent(
+    name="parallel_intake",
+    description="Runs research and compliance in parallel.",
+    sub_agents=[research_agent, compliance_agent],
+)
+
+risk_agent = LlmAgent(
+    name="risk_agent",
+    model=HAIKU,
+    description="Evaluates client risk based on research and compliance findings.",
+    instruction="You are the Risk Agent. Read {research_output} and {compliance_output}, then use compute_risk_score to assess risk. Provide recommendation.",
+    tools=[compute_risk_score],
+    output_key="risk_output",
+)
+
+synthesis_agent = LlmAgent(
+    name="synthesis_agent",
+    model=OPUS,
+    description="Synthesizes deal package and logs to BigQuery.",
+    instruction="You are the Synthesis Agent. Read {research_output}, {compliance_output}, {risk_output}. Use insert_deal_package to log the deal and update_client_status to activate the client.",
+    tools=[insert_deal_package, update_client_status],
+    output_key="deal_package",
+)
+
+post_intake = SequentialAgent(
+    name="post_intake",
+    sub_agents=[risk_agent, synthesis_agent],
+)
+
+deal_desk_pipeline = SequentialAgent(
+    name="deal_desk_pipeline",
+    description="Full onboarding pipeline: parallel research + compliance, then risk scoring, then deal synthesis. Use this when the user asks to onboard a client or run the full pipeline.",
+    sub_agents=[parallel_intake, post_intake],
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ROOT AGENT — Conversational with pipeline delegation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+root_agent = LlmAgent(
+    name="deal_desk_agent",
+    model=SONNET,
+    description="Conversational FSI Deal Desk agent with data access and onboarding pipeline.",
+    instruction="""You are the Deal Desk Agent, a professional AI assistant for financial services deal management at a hedge fund.
+
+You are powered by Claude AI models on Google Cloud Vertex AI, orchestrated by Google's Agent Development Kit (ADK).
+
+YOUR CAPABILITIES:
+1. **Data Queries**: List all clients, look up specific clients, check compliance records, view market intelligence, and review deal packages. Use the appropriate tool for each query.
+2. **Client Onboarding**: When the user asks to onboard a client, run compliance checks, or process a deal — delegate to the deal_desk_pipeline sub-agent which runs the full parallel pipeline (research + compliance → risk → synthesis).
+3. **Compliance Checks**: Query compliance records for any client.
+
+GUIDELINES:
+- When the user says "show me our clients" or "list clients", use the list_all_clients tool and present the results in a clear table format.
+- When the user asks about a specific client, use query_client_data to look them up.
+- When the user asks to onboard a client or run the full pipeline, delegate to the deal_desk_pipeline.
+- Always present BigQuery data in clean, formatted tables with columns for key fields.
+- When the user asks to onboard a client, create a Salesforce Opportunity, or process a deal, ALWAYS use trigger_salesforce_opportunity with the client name. This is the primary action tool. Always include the live_view_url from the tool result in your response so the user can watch the agent work.
+- Do NOT delegate to deal_desk_pipeline for onboarding requests — use trigger_salesforce_opportunity directly.
+- IMPORTANT: If the user says "thank you", "thanks", "ok", "done", or any short acknowledgment, DO NOT trigger any tools. Instead, respond with a warm, professional farewell like "You're welcome! Let me know if you need anything else." Always respond with text — never return an empty response.
+- Be warm, professional, and concise.
+- Mention that data is pulled live from BigQuery via Google Cloud.""",
+    tools=[
+        list_all_clients,
+        list_all_compliance,
+        list_deal_packages,
+        query_client_data,
+        query_market_intelligence,
+        query_compliance_records,
+        trigger_salesforce_opportunity,
+    ],
+    sub_agents=[deal_desk_pipeline],
+)

--- a/03-demos/deal-desk-agent/agent_deploy/requirements.txt
+++ b/03-demos/deal-desk-agent/agent_deploy/requirements.txt
@@ -1,0 +1,6 @@
+google-cloud-aiplatform[agent_engines,adk]
+google-adk>=1.2.0
+anthropic[vertex]>=0.43.0
+google-cloud-bigquery>=3.27.0
+cloudpickle>=3.0.0
+pydantic>=2.0.0

--- a/03-demos/deal-desk-agent/agent_deploy/risk_scoring.py
+++ b/03-demos/deal-desk-agent/agent_deploy/risk_scoring.py
@@ -1,0 +1,196 @@
+"""
+Risk scoring tool for the Deal Desk Agent.
+Computes a weighted risk score based on client profile and compliance data.
+Called by the Risk Scoring Agent (Haiku 4.5) for fast evaluation.
+"""
+
+
+# ─── Weight configuration ───
+WEIGHTS = {
+    "aum_size": 0.15,
+    "domicile": 0.20,
+    "strategy_complexity": 0.15,
+    "kyc_status": 0.20,
+    "aml_status": 0.15,
+    "sanctions_status": 0.15,
+}
+
+# ─── Scoring tables ───
+DOMICILE_RISK = {
+    "united states": 0.1,
+    "canada": 0.15,
+    "united kingdom": 0.15,
+    "singapore": 0.25,
+    "hong kong": 0.30,
+    "cayman islands": 0.45,
+    "british virgin islands": 0.55,
+    "luxembourg": 0.20,
+    "switzerland": 0.20,
+}
+
+STRATEGY_RISK = {
+    "long/short equity": 0.20,
+    "global macro": 0.35,
+    "multi-strategy": 0.30,
+    "quantitative equity": 0.25,
+    "credit/distressed": 0.45,
+    "systematic futures": 0.30,
+    "private equity": 0.20,
+    "event-driven": 0.35,
+    "emerging markets": 0.50,
+}
+
+STATUS_RISK = {
+    "VERIFIED": 0.0,
+    "CLEAR": 0.0,
+    "PENDING": 0.5,
+    "REVIEW": 0.7,
+    "FAILED": 1.0,
+    "EXPIRED": 0.6,
+}
+
+TIER_THRESHOLDS = {
+    "LOW": (0.0, 0.30),
+    "MEDIUM": (0.30, 0.55),
+    "HIGH": (0.55, 1.0),
+}
+
+
+def _score_aum(aum_millions: float) -> float:
+    """Larger AUM = lower risk (more institutional, more oversight)."""
+    if aum_millions >= 1000:
+        return 0.10
+    elif aum_millions >= 500:
+        return 0.20
+    elif aum_millions >= 200:
+        return 0.30
+    elif aum_millions >= 100:
+        return 0.45
+    else:
+        return 0.60
+
+
+def _score_domicile(domicile: str) -> float:
+    """Score based on jurisdiction regulatory strength."""
+    return DOMICILE_RISK.get(domicile.lower(), 0.50)
+
+
+def _score_strategy(strategy: str) -> float:
+    """Score based on strategy complexity and risk profile."""
+    return STRATEGY_RISK.get(strategy.lower(), 0.40)
+
+
+def _score_status(status: str) -> float:
+    """Score a compliance status field."""
+    return STATUS_RISK.get(status, 0.5)
+
+
+def _determine_tier(score: float) -> str:
+    """Map numeric score to risk tier."""
+    for tier, (low, high) in TIER_THRESHOLDS.items():
+        if low <= score < high:
+            return tier
+    return "HIGH"
+
+
+def compute_risk_score(
+    client_name: str,
+    aum_millions: float,
+    strategy: str,
+    domicile: str,
+    kyc_status: str,
+    aml_status: str,
+    sanctions_status: str
+) -> dict:
+    """
+    Compute a weighted risk score for a client based on their profile
+    and compliance data. Returns the score, tier, and a breakdown of
+    contributing factors.
+
+    Args:
+        client_name: Name of the client.
+        aum_millions: Assets under management in millions.
+        strategy: Investment strategy.
+        domicile: Country/jurisdiction of domicile.
+        kyc_status: KYC verification status.
+        aml_status: AML screening status.
+        sanctions_status: Sanctions screening status.
+
+    Returns:
+        dict with risk_score (0-1), risk_tier, confidence, and
+        a breakdown of individual factor scores with explanations.
+    """
+    factors = {
+        "aum_size": {
+            "score": _score_aum(aum_millions),
+            "weight": WEIGHTS["aum_size"],
+            "detail": f"AUM ${aum_millions}M — {'large institutional' if aum_millions >= 500 else 'mid-size' if aum_millions >= 200 else 'smaller fund'}"
+        },
+        "domicile": {
+            "score": _score_domicile(domicile),
+            "weight": WEIGHTS["domicile"],
+            "detail": f"{domicile} — {'strong' if _score_domicile(domicile) < 0.25 else 'moderate' if _score_domicile(domicile) < 0.4 else 'elevated'} regulatory environment"
+        },
+        "strategy_complexity": {
+            "score": _score_strategy(strategy),
+            "weight": WEIGHTS["strategy_complexity"],
+            "detail": f"{strategy} — {'standard' if _score_strategy(strategy) < 0.3 else 'moderate' if _score_strategy(strategy) < 0.4 else 'complex'} risk profile"
+        },
+        "kyc_status": {
+            "score": _score_status(kyc_status),
+            "weight": WEIGHTS["kyc_status"],
+            "detail": f"KYC: {kyc_status}"
+        },
+        "aml_status": {
+            "score": _score_status(aml_status),
+            "weight": WEIGHTS["aml_status"],
+            "detail": f"AML: {aml_status}"
+        },
+        "sanctions_status": {
+            "score": _score_status(sanctions_status),
+            "weight": WEIGHTS["sanctions_status"],
+            "detail": f"Sanctions: {sanctions_status}"
+        },
+    }
+
+    # Compute weighted score
+    total_score = sum(
+        f["score"] * f["weight"] for f in factors.values()
+    )
+    total_score = round(min(max(total_score, 0.0), 1.0), 4)
+
+    # Confidence based on data completeness
+    pending_count = sum(
+        1 for s in [kyc_status, aml_status, sanctions_status]
+        if s in ("PENDING", "REVIEW")
+    )
+    confidence = round(1.0 - (pending_count * 0.15), 2)
+
+    tier = _determine_tier(total_score)
+
+    # Flag any blockers
+    blockers = []
+    if kyc_status == "PENDING":
+        blockers.append("KYC verification pending — onboarding blocked until resolved")
+    if sanctions_status == "REVIEW":
+        blockers.append("Sanctions screening under review — requires manual clearance")
+    if aml_status == "REVIEW":
+        blockers.append("AML review in progress — requires senior compliance sign-off")
+
+    return {
+        "client_name": client_name,
+        "risk_score": total_score,
+        "risk_tier": tier,
+        "confidence": confidence,
+        "blockers": blockers,
+        "factors": {
+            k: {"score": round(v["score"], 3), "weighted": round(v["score"] * v["weight"], 4), "detail": v["detail"]}
+            for k, v in factors.items()
+        },
+        "recommendation": (
+            "APPROVE — proceed with onboarding" if tier == "LOW" and not blockers
+            else "APPROVE WITH CONDITIONS — review flagged items" if tier == "MEDIUM" and not blockers
+            else "HOLD — resolve blockers before proceeding" if blockers
+            else "ESCALATE — requires senior risk committee review"
+        )
+    }

--- a/03-demos/deal-desk-agent/agent_deploy/tools.py
+++ b/03-demos/deal-desk-agent/agent_deploy/tools.py
@@ -1,0 +1,380 @@
+"""
+BigQuery tools for the Deal Desk Agent.
+Read and write operations against the deal_desk_agent dataset.
+Used by ADK agents via tool definitions.
+"""
+
+import os
+import uuid
+from datetime import datetime
+from google.cloud import bigquery
+
+PROJECT_ID = os.environ.get("PROJECT_ID", "cpe-slarbi-nvd-ant-demos")
+DATASET = os.environ.get("BQ_DATASET", "deal_desk_agent")
+
+_client = None
+
+def _get_client():
+    """Lazy-init BigQuery client."""
+    global _client
+    if _client is None:
+        _client = bigquery.Client(project=PROJECT_ID)
+    return _client
+
+
+def _run_query(sql: str, params: list = None) -> list[dict]:
+    """Execute a parameterized query and return rows as dicts."""
+    client = _get_client()
+    job_config = bigquery.QueryJobConfig()
+    if params:
+        job_config.query_parameters = params
+    rows = client.query(sql, job_config=job_config).result()
+    results = []
+    for row in rows:
+        d = dict(row)
+        for k, v in d.items():
+            if hasattr(v, "isoformat"):
+                d[k] = v.isoformat()
+        results.append(d)
+    return results
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# READ TOOLS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def query_client_data(client_name: str) -> dict:
+    """
+    Look up a client by name in the clients table.
+    Returns client profile including AUM, strategy, fee structure,
+    relationship status, and primary contact.
+
+    Args:
+        client_name: Full or partial name of the client to search for.
+
+    Returns:
+        dict with 'found' boolean and 'results' list of matching client records.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.clients`
+        WHERE LOWER(name) LIKE LOWER(@search_term)
+        ORDER BY aum_millions DESC
+    """
+    params = [
+        bigquery.ScalarQueryParameter("search_term", "STRING", f"%{client_name}%")
+    ]
+    results = _run_query(sql, params)
+    return {
+        "found": len(results) > 0,
+        "match_count": len(results),
+        "results": results
+    }
+
+
+def query_market_intelligence(client_name: str) -> dict:
+    """
+    Retrieve recent market intelligence for a given client.
+    Returns SEC filings, news articles, and market data sorted by relevance.
+
+    Args:
+        client_name: Full or partial name of the client.
+
+    Returns:
+        dict with 'found' boolean and 'intel' list of intelligence records.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.market_intelligence`
+        WHERE LOWER(client_name) LIKE LOWER(@search_term)
+        ORDER BY relevance_score DESC, date DESC
+    """
+    params = [
+        bigquery.ScalarQueryParameter("search_term", "STRING", f"%{client_name}%")
+    ]
+    results = _run_query(sql, params)
+    return {
+        "found": len(results) > 0,
+        "record_count": len(results),
+        "intel": results
+    }
+
+
+def query_compliance_records(client_name: str) -> dict:
+    """
+    Retrieve compliance records for a given client.
+    Returns KYC status, AML status, sanctions screening, FINRA registration,
+    and risk tier.
+
+    Args:
+        client_name: Full or partial name of the client.
+
+    Returns:
+        dict with 'found' boolean and 'records' list of compliance data.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.compliance_records`
+        WHERE LOWER(client_name) LIKE LOWER(@search_term)
+    """
+    params = [
+        bigquery.ScalarQueryParameter("search_term", "STRING", f"%{client_name}%")
+    ]
+    results = _run_query(sql, params)
+    return {
+        "found": len(results) > 0,
+        "records": results
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# WRITE TOOLS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def update_client_status(client_name: str, new_status: str) -> dict:
+    """
+    Update a client's relationship status after onboarding.
+    Typically changes status from 'Prospect' or 'Returning' to 'Active'.
+
+    Args:
+        client_name: Exact name of the client to update.
+        new_status: New relationship status (e.g., 'Active').
+
+    Returns:
+        dict with 'success' boolean and 'rows_updated' count.
+    """
+    sql = f"""
+        UPDATE `{PROJECT_ID}.{DATASET}.clients`
+        SET relationship_status = @new_status
+        WHERE LOWER(name) = LOWER(@client_name)
+    """
+    params = [
+        bigquery.ScalarQueryParameter("new_status", "STRING", new_status),
+        bigquery.ScalarQueryParameter("client_name", "STRING", client_name),
+    ]
+    client = _get_client()
+    job_config = bigquery.QueryJobConfig(query_parameters=params)
+    result = client.query(sql, job_config=job_config).result()
+    rows_affected = result.num_dml_affected_rows or 0
+    return {
+        "success": rows_affected > 0,
+        "rows_updated": rows_affected,
+        "client_name": client_name,
+        "new_status": new_status
+    }
+
+
+def insert_deal_package(
+    client_name: str,
+    aum_millions: float,
+    strategy: str,
+    mandate_type: str,
+    fee_structure: str,
+    compliance_status: str,
+    risk_tier: str,
+    risk_score: float,
+    primary_contact: str,
+    primary_contact_title: str,
+    notes: str = ""
+) -> dict:
+    """
+    Insert a completed deal package into the deal_packages table.
+    Creates an audit record of the agent's work.
+
+    Args:
+        client_name: Name of the client.
+        aum_millions: Assets under management in millions.
+        strategy: Investment strategy.
+        mandate_type: Type of mandate (e.g., 'Long/Short Equity').
+        fee_structure: Fee structure (e.g., '2/20').
+        compliance_status: Overall compliance result (e.g., 'CLEARED').
+        risk_tier: Risk tier assigned (e.g., 'MEDIUM').
+        risk_score: Numeric risk score (0.0 to 1.0).
+        primary_contact: Name of primary contact.
+        primary_contact_title: Title of primary contact.
+        notes: Additional notes from the synthesis agent.
+
+    Returns:
+        dict with 'success' boolean and the generated 'deal_id'.
+    """
+    deal_id = f"DEAL-{uuid.uuid4().hex[:8].upper()}"
+    sql = f"""
+        INSERT INTO `{PROJECT_ID}.{DATASET}.deal_packages`
+        (deal_id, client_name, aum_millions, strategy, mandate_type,
+         fee_structure, compliance_status, risk_tier, risk_score,
+         primary_contact, primary_contact_title, salesforce_opportunity_id,
+         status, created_by, created_at, notes)
+        VALUES
+        (@deal_id, @client_name, @aum_millions, @strategy, @mandate_type,
+         @fee_structure, @compliance_status, @risk_tier, @risk_score,
+         @primary_contact, @primary_contact_title, NULL,
+         'PENDING_SF_ENTRY', 'deal_desk_agent', CURRENT_TIMESTAMP(), @notes)
+    """
+    params = [
+        bigquery.ScalarQueryParameter("deal_id", "STRING", deal_id),
+        bigquery.ScalarQueryParameter("client_name", "STRING", client_name),
+        bigquery.ScalarQueryParameter("aum_millions", "FLOAT64", aum_millions),
+        bigquery.ScalarQueryParameter("strategy", "STRING", strategy),
+        bigquery.ScalarQueryParameter("mandate_type", "STRING", mandate_type),
+        bigquery.ScalarQueryParameter("fee_structure", "STRING", fee_structure),
+        bigquery.ScalarQueryParameter("compliance_status", "STRING", compliance_status),
+        bigquery.ScalarQueryParameter("risk_tier", "STRING", risk_tier),
+        bigquery.ScalarQueryParameter("risk_score", "FLOAT64", risk_score),
+        bigquery.ScalarQueryParameter("primary_contact", "STRING", primary_contact),
+        bigquery.ScalarQueryParameter("primary_contact_title", "STRING", primary_contact_title),
+        bigquery.ScalarQueryParameter("notes", "STRING", notes),
+    ]
+    client = _get_client()
+    job_config = bigquery.QueryJobConfig(query_parameters=params)
+    client.query(sql, job_config=job_config).result()
+    return {
+        "success": True,
+        "deal_id": deal_id,
+        "client_name": client_name,
+        "status": "PENDING_SF_ENTRY"
+    }
+
+
+def update_deal_with_sf_opportunity(deal_id: str, opportunity_id: str) -> dict:
+    """
+    Stamp a Salesforce opportunity ID onto a deal package record.
+    Called by the Salesforce browser agent after creating the opportunity.
+
+    Args:
+        deal_id: The deal package ID (e.g., 'DEAL-A1B2C3D4').
+        opportunity_id: The Salesforce opportunity ID (e.g., 'OPP-006Xx000001abc').
+
+    Returns:
+        dict with 'success' boolean.
+    """
+    sql = f"""
+        UPDATE `{PROJECT_ID}.{DATASET}.deal_packages`
+        SET salesforce_opportunity_id = @opportunity_id,
+            status = 'COMPLETED'
+        WHERE deal_id = @deal_id
+    """
+    params = [
+        bigquery.ScalarQueryParameter("opportunity_id", "STRING", opportunity_id),
+        bigquery.ScalarQueryParameter("deal_id", "STRING", deal_id),
+    ]
+    client = _get_client()
+    job_config = bigquery.QueryJobConfig(query_parameters=params)
+    result = client.query(sql, job_config=job_config).result()
+    rows_affected = result.num_dml_affected_rows or 0
+    return {
+        "success": rows_affected > 0,
+        "deal_id": deal_id,
+        "salesforce_opportunity_id": opportunity_id,
+        "status": "COMPLETED"
+    }
+
+
+def list_all_clients() -> dict:
+    """
+    List ALL clients in the database.
+    Use this when the user asks to see all clients, the full roster,
+    or says things like "show me our clients" or "who are our clients".
+    Returns all client records sorted by AUM.
+
+    Returns:
+        dict with client_count and list of all client records.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.clients`
+        ORDER BY aum_millions DESC
+    """
+    results = _run_query(sql)
+    return {
+        "client_count": len(results),
+        "results": results
+    }
+
+
+def list_all_compliance() -> dict:
+    """
+    List ALL compliance records in the database.
+    Use this when the user asks about compliance status across all clients.
+
+    Returns:
+        dict with record_count and list of compliance records.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.compliance_records`
+        ORDER BY risk_tier
+    """
+    results = _run_query(sql)
+    return {
+        "record_count": len(results),
+        "records": results
+    }
+
+
+def list_deal_packages() -> dict:
+    """
+    List recent deal packages created by the pipeline.
+    Use this when the user asks about recent deals or pipeline output.
+
+    Returns:
+        dict with deal_count and list of deal package records.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.deal_packages`
+        ORDER BY created_at DESC
+        LIMIT 10
+    """
+    results = _run_query(sql)
+    return {
+        "deal_count": len(results),
+        "deals": results
+    }
+
+
+def trigger_salesforce_opportunity(client_name: str) -> dict:
+    """
+    Trigger the Salesforce browser agent to create an Opportunity for a client.
+    Routes through Cloud Run backend (Agent Engine cannot reach GCE VMs directly,
+    and Cloud Run holds the AGENT_SECRET needed to authenticate to the VM's
+    /run endpoint — see README "Security" section).
+
+    Args:
+        client_name: Full or partial name of the client to create an opportunity for.
+
+    Returns:
+        dict with status, client details, and a live view URL.
+    """
+    import httpx
+
+    BACKEND_URL = "https://deal-desk-backend-436293010210.us-central1.run.app"
+    NOVNC_URL = "http://35.223.98.125:6080/vnc.html?autoconnect=true"
+
+    try:
+        resp = httpx.post(
+            f"{BACKEND_URL}/api/trigger-sf",
+            json={"client_name": client_name},
+            timeout=15.0,
+        )
+        result = resp.json()
+        if result.get("success"):
+            return {
+                "success": True,
+                "client_name": result.get("client_name", client_name),
+                "aum_millions": result.get("aum_millions", 0),
+                "strategy": result.get("strategy", "Unknown"),
+                "message": f"Salesforce Opportunity is being created for {result.get('client_name', client_name)}!",
+                "live_view_url": NOVNC_URL,
+                "instruction_for_user": f"Watch the agent navigate Salesforce live: {NOVNC_URL}",
+            }
+        else:
+            return {
+                "success": False,
+                "error": result.get("error", "Unknown error"),
+                "suggestion": "Use list_all_clients to see available clients.",
+            }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": f"Failed to trigger Salesforce: {str(e)}",
+        }

--- a/03-demos/deal-desk-agent/backend/Dockerfile
+++ b/03-demos/deal-desk-agent/backend/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+# Prevent Python from writing .pyc files and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Cloud Run uses PORT env var (defaults to 8080)
+ENV PORT=8080
+
+# Run with uvicorn
+CMD ["python", "main.py"]

--- a/03-demos/deal-desk-agent/backend/agents/__init__.py
+++ b/03-demos/deal-desk-agent/backend/agents/__init__.py
@@ -1,0 +1,19 @@
+from .deal_desk_swarm import (
+    deal_desk_pipeline,
+    research_agent,
+    compliance_agent,
+    risk_agent,
+    synthesis_agent,
+    parallel_intake,
+    get_model,
+)
+
+__all__ = [
+    "deal_desk_pipeline",
+    "research_agent",
+    "compliance_agent",
+    "risk_agent",
+    "synthesis_agent",
+    "parallel_intake",
+    "get_model",
+]

--- a/03-demos/deal-desk-agent/backend/agents/agent_card.json
+++ b/03-demos/deal-desk-agent/backend/agents/agent_card.json
@@ -1,0 +1,110 @@
+{
+  "name": "deal-desk-agent",
+  "display_name": "FSI Deal Desk Agent",
+  "description": "End-to-end deal desk pipeline for FSI client onboarding. Runs parallel research and compliance checks, computes risk scoring, synthesizes a deal package, and creates a Salesforce opportunity — all powered by Claude models on Vertex AI, orchestrated by Google ADK.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Google Cloud — Partner Technical Architecture",
+    "contact": "slarbi@google.com"
+  },
+  "url": "https://deal-desk-agent-REGION-run.app",
+  "protocol": "a2a/1.0",
+  "capabilities": {
+    "input": {
+      "type": "text",
+      "description": "Natural language description of a client to onboard, including client name, AUM, strategy, mandate type, fee structure, and primary contact.",
+      "examples": [
+        "Onboard new client: ACME Capital Management. $250M AUM, long/short equity mandate, 2/20 fee structure, institutional investor. Primary contact: Sarah Chen, CIO.",
+        "Run full compliance review for Beacon Hedge Fund. $500M AUM, global macro strategy, Cayman domiciled."
+      ]
+    },
+    "output": {
+      "type": "structured",
+      "description": "A complete deal package containing client profile, compliance determination, risk assessment, deal ID, and Salesforce opportunity ID.",
+      "schema": {
+        "deal_id": "string",
+        "client_name": "string",
+        "aum_millions": "number",
+        "strategy": "string",
+        "mandate_type": "string",
+        "fee_structure": "string",
+        "compliance_status": "string (CLEARED | BLOCKED | CONDITIONAL)",
+        "risk_tier": "string (LOW | MEDIUM | HIGH)",
+        "risk_score": "number (0.0-1.0)",
+        "primary_contact": "string",
+        "primary_contact_title": "string",
+        "salesforce_opportunity_id": "string | null",
+        "status": "string (APPROVED | APPROVED_WITH_CONDITIONS | ON_HOLD | ESCALATED)",
+        "notes": "string"
+      }
+    },
+    "streaming": true,
+    "human_in_the_loop": false
+  },
+  "agents": [
+    {
+      "name": "research_agent",
+      "model": "claude-opus-4-5@20251101",
+      "role": "Client research and market intelligence gathering",
+      "tools": ["query_client_data", "query_market_intelligence"]
+    },
+    {
+      "name": "compliance_agent",
+      "model": "claude-sonnet-4-6@default",
+      "role": "KYC, AML, sanctions, and FINRA compliance verification",
+      "tools": ["query_compliance_records"]
+    },
+    {
+      "name": "risk_agent",
+      "model": "claude-haiku-4-5@20251001",
+      "role": "Quantitative risk scoring and tier assignment",
+      "tools": ["compute_risk_score"]
+    },
+    {
+      "name": "synthesis_agent",
+      "model": "claude-opus-4-5@20251101",
+      "role": "Deal package synthesis and BigQuery logging",
+      "tools": ["insert_deal_package", "update_client_status"]
+    },
+    {
+      "name": "salesforce_agent",
+      "model": "claude-sonnet-4-6@default",
+      "role": "Browser-based Salesforce opportunity creation via computer use",
+      "tools": ["computer_use", "screenshot"]
+    }
+  ],
+  "orchestration": {
+    "pattern": "sequential",
+    "stages": [
+      {
+        "name": "parallel_intake",
+        "type": "parallel",
+        "agents": ["research_agent", "compliance_agent"]
+      },
+      {
+        "name": "risk_assessment",
+        "type": "sequential",
+        "agents": ["risk_agent"]
+      },
+      {
+        "name": "synthesis",
+        "type": "sequential",
+        "agents": ["synthesis_agent"]
+      },
+      {
+        "name": "crm_entry",
+        "type": "sequential",
+        "agents": ["salesforce_agent"]
+      }
+    ]
+  },
+  "infrastructure": {
+    "platform": "Google Cloud",
+    "runtime": "Vertex AI Agent Engine",
+    "model_provider": "Anthropic (Claude on Vertex AI)",
+    "data_services": ["BigQuery", "Cloud SQL"],
+    "deployment": "Cloud Run",
+    "security": ["VPC Service Controls", "Cloud Armor", "IAM"]
+  },
+  "tags": ["fsi", "deal-desk", "onboarding", "compliance", "multi-agent", "computer-use"]
+}

--- a/03-demos/deal-desk-agent/backend/agents/deal_desk_swarm.py
+++ b/03-demos/deal-desk-agent/backend/agents/deal_desk_swarm.py
@@ -1,0 +1,208 @@
+"""
+Deal Desk Agent Swarm — ADK orchestration for the Deal Desk pipeline.
+Powered by Claude models on Vertex AI, with Gemini swap capability for future use.
+
+Architecture:
+  ParallelAgent (Research + Compliance)
+    → SequentialAgent (Risk → Synthesis)
+
+All agents write to shared session state via output_key.
+"""
+
+import os
+from google.adk.agents import LlmAgent, SequentialAgent, ParallelAgent
+from google.adk.models.anthropic_llm import Claude
+from google.adk.models.registry import LLMRegistry
+
+from tools.bigquery_tools import (
+    query_client_data,
+    query_market_intelligence,
+    query_compliance_records,
+    update_client_status,
+    insert_deal_package,
+)
+from tools.risk_scoring import compute_risk_score
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MODEL CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+MODEL_PROVIDER = os.environ.get("MODEL_PROVIDER", "claude")
+
+# Claude on Vertex AI (default for NEXT demo)
+CLAUDE_MODELS = {
+    "opus": os.environ.get("OPUS_MODEL", "claude-opus-4-5@20251101"),
+    "sonnet": os.environ.get("SONNET_MODEL", "claude-sonnet-4-6@default"),
+    "haiku": os.environ.get("HAIKU_MODEL", "claude-haiku-4-5@20251001"),
+}
+
+# Gemini on Vertex AI (future use)
+GEMINI_MODELS = {
+    "opus": os.environ.get("GEMINI_LARGE", "gemini-2.5-pro"),
+    "sonnet": os.environ.get("GEMINI_MID", "gemini-2.5-flash"),
+    "haiku": os.environ.get("GEMINI_SMALL", "gemini-2.5-flash-lite"),
+}
+
+
+def get_model(tier: str) -> str:
+    """
+    Return the model string for a given tier (opus/sonnet/haiku).
+    Reads MODEL_PROVIDER env var to swap between Claude and Gemini.
+    """
+    if MODEL_PROVIDER == "gemini":
+        return GEMINI_MODELS[tier]
+    return CLAUDE_MODELS[tier]
+
+
+# Register Claude wrapper so ADK recognizes Claude model strings
+if MODEL_PROVIDER == "claude":
+    LLMRegistry.register(Claude)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# AGENT DEFINITIONS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ─── Research Agent (Opus 4.5) ────────────────────────────────────────────────
+research_agent = LlmAgent(
+    name="research_agent",
+    model=get_model("opus"),
+    description="Researches client background, prior relationships, and market intelligence.",
+    instruction="""You are the Research Agent in an FSI Deal Desk pipeline.
+Your job is to gather comprehensive intelligence on the client being onboarded.
+
+When given a client name and details:
+1. Use query_client_data to look up any existing records for this client.
+2. Use query_market_intelligence to find recent SEC filings, news, and market data.
+3. Synthesize your findings into a structured research brief.
+
+Your output should include:
+- Whether the client is new or has a prior relationship
+- Key financial data (AUM, strategy, recent performance if available)
+- Relevant market intelligence (filings, news, hiring signals)
+- Any notable items that compliance or risk should be aware of
+
+Be thorough but concise. Write for a senior portfolio manager audience.""",
+    tools=[query_client_data, query_market_intelligence],
+    output_key="research_output",
+)
+
+# ─── Compliance Agent (Sonnet 4.6) ────────────────────────────────────────────
+compliance_agent = LlmAgent(
+    name="compliance_agent",
+    model=get_model("sonnet"),
+    description="Runs KYC, AML, sanctions, and FINRA compliance checks.",
+    instruction="""You are the Compliance Agent in an FSI Deal Desk pipeline.
+Your job is to verify that a client passes all regulatory requirements.
+
+When given a client name and details:
+1. Use query_compliance_records to retrieve existing compliance data.
+2. Evaluate each compliance dimension:
+   - KYC (Know Your Customer) verification status
+   - AML (Anti-Money Laundering) screening
+   - Sanctions screening (OFAC, EU, UN)
+   - FINRA registration and disclosure history
+3. Provide a clear compliance determination.
+
+Your output should include:
+- Status for each compliance check (CLEAR / PENDING / REVIEW / FAILED)
+- Overall compliance determination (CLEARED / BLOCKED / CONDITIONAL)
+- Any items requiring manual review or escalation
+- Recommended next steps if any checks are not clear
+
+Flag any blockers immediately. Do not soft-pedal compliance issues.""",
+    tools=[query_compliance_records],
+    output_key="compliance_output",
+)
+
+# ─── Parallel Intake (Research + Compliance run simultaneously) ────────────────
+parallel_intake = ParallelAgent(
+    name="parallel_intake",
+    description="Runs research and compliance checks in parallel for efficiency.",
+    sub_agents=[research_agent, compliance_agent],
+)
+
+# ─── Risk Scoring Agent (Haiku 4.5) ──────────────────────────────────────────
+risk_agent = LlmAgent(
+    name="risk_agent",
+    model=get_model("haiku"),
+    description="Evaluates client risk based on research and compliance findings.",
+    instruction="""You are the Risk Scoring Agent in an FSI Deal Desk pipeline.
+Your job is to assess the overall risk of onboarding this client.
+
+You have access to:
+- Research findings in {research_output}
+- Compliance findings in {compliance_output}
+
+Steps:
+1. Extract the key risk factors from the research and compliance outputs:
+   client name, AUM, strategy, domicile, KYC status, AML status, sanctions status.
+2. Use compute_risk_score with these parameters to get a quantitative assessment.
+3. Review the score, tier, and any blockers returned.
+4. Provide your risk assessment with a clear recommendation.
+
+Your output should include:
+- The numeric risk score and tier
+- Key risk factors and their contributions
+- Any blockers that prevent onboarding
+- Your recommendation: APPROVE / APPROVE WITH CONDITIONS / HOLD / ESCALATE
+
+Be decisive. Risk assessments must be clear and actionable.""",
+    tools=[compute_risk_score],
+    output_key="risk_output",
+)
+
+# ─── Synthesis Agent (Opus 4.5) ──────────────────────────────────────────────
+synthesis_agent = LlmAgent(
+    name="synthesis_agent",
+    model=get_model("opus"),
+    description="Synthesizes all findings into a deal package and logs it to BigQuery.",
+    instruction="""You are the Synthesis Agent in an FSI Deal Desk pipeline.
+Your job is to produce the final deal package and log it to the system of record.
+
+You have access to:
+- Research findings in {research_output}
+- Compliance findings in {compliance_output}
+- Risk assessment in {risk_output}
+
+Steps:
+1. Review all three inputs and produce a structured deal summary.
+2. If compliance is CLEARED and risk recommendation is APPROVE or APPROVE WITH CONDITIONS:
+   a. Use insert_deal_package to log the deal to BigQuery with all relevant fields.
+   b. Use update_client_status to set the client's relationship status to 'Active'.
+3. If compliance is BLOCKED or risk says HOLD/ESCALATE:
+   a. Still log the deal with appropriate status and notes explaining why it was held.
+   b. Do NOT update client status.
+
+Your final output should be a structured deal package containing:
+- Client name, AUM, strategy, mandate type, fee structure
+- Compliance status summary
+- Risk tier and score
+- Primary contact name and title
+- Deal ID (from the insert_deal_package response)
+- Status: APPROVED / APPROVED_WITH_CONDITIONS / ON_HOLD / ESCALATED
+- Summary notes explaining the decision
+
+This deal package will be passed to the Salesforce Agent for CRM entry.""",
+    tools=[insert_deal_package, update_client_status],
+    output_key="deal_package",
+)
+
+# ─── Sequential Pipeline (Risk → Synthesis, runs after parallel intake) ───────
+post_intake_pipeline = SequentialAgent(
+    name="post_intake_pipeline",
+    description="Runs risk assessment then synthesis sequentially after parallel intake.",
+    sub_agents=[risk_agent, synthesis_agent],
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TOP-LEVEL PIPELINE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+deal_desk_pipeline = SequentialAgent(
+    name="deal_desk_pipeline",
+    description="""End-to-end Deal Desk pipeline for FSI client onboarding.
+    Runs research and compliance in parallel, then risk scoring, then synthesis.
+    Produces a complete deal package ready for Salesforce entry.""",
+    sub_agents=[parallel_intake, post_intake_pipeline],
+)

--- a/03-demos/deal-desk-agent/backend/agents/salesforce_browser_agent.py
+++ b/03-demos/deal-desk-agent/backend/agents/salesforce_browser_agent.py
@@ -1,0 +1,470 @@
+"""
+Salesforce Browser Agent — Computer Use integration.
+Drives a live Salesforce instance via Claude's computer use API on Vertex AI.
+Runs inside a Docker container with a virtual desktop (Xvfb + Chrome + noVNC).
+
+This agent is separate from the ADK pipeline because it uses the computer use
+tool loop pattern rather than standard ADK tool calling.
+"""
+
+import os
+import json
+import base64
+import subprocess
+import logging
+import asyncio
+from datetime import datetime
+from typing import AsyncGenerator
+
+import httpx
+import google.auth
+import google.auth.transport.requests
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONFIG
+# ═══════════════════════════════════════════════════════════════════════════════
+
+PROJECT_ID = os.environ.get("PROJECT_ID", "cpe-slarbi-nvd-ant-demos")
+REGION = os.environ.get("REGION", "us-east5")
+SONNET_MODEL = os.environ.get("SONNET_MODEL", "claude-sonnet-4-6@default")
+SALESFORCE_URL = os.environ.get(
+    "SALESFORCE_URL",
+    "https://orgfarm-09257c3eee-dev-ed.develop.lightning.force.com"
+)
+
+# Computer use settings
+DISPLAY_WIDTH = int(os.environ.get("DISPLAY_WIDTH", 1280))
+DISPLAY_HEIGHT = int(os.environ.get("DISPLAY_HEIGHT", 800))
+SCREENSHOT_PATH = "/tmp/screenshot.png"
+MAX_ITERATIONS = int(os.environ.get("CU_MAX_ITERATIONS", 40))
+
+# Vertex AI endpoint
+VERTEX_ENDPOINT = (
+    f"https://{REGION}-aiplatform.googleapis.com/v1/"
+    f"projects/{PROJECT_ID}/locations/{REGION}/"
+    f"publishers/anthropic/models/{SONNET_MODEL}:rawPredict"
+)
+
+BETA_HEADER = "computer-use-2025-11-24"
+
+logger = logging.getLogger("salesforce-browser-agent")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# AUTH
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def get_access_token() -> str:
+    """Get a fresh GCP access token via ADC."""
+    credentials, _ = google.auth.default()
+    credentials.refresh(google.auth.transport.requests.Request())
+    return credentials.token
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SCREENSHOT + ACTION EXECUTION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def take_screenshot() -> str:
+    """Capture the virtual display and return base64-encoded PNG."""
+    subprocess.run(
+        ["scrot", "-o", SCREENSHOT_PATH],
+        env={**os.environ, "DISPLAY": ":1"},
+        check=True,
+        capture_output=True,
+    )
+    with open(SCREENSHOT_PATH, "rb") as f:
+        return base64.standard_b64encode(f.read()).decode("utf-8")
+
+
+def execute_action(action: dict) -> dict:
+    """
+    Execute a computer use action on the virtual desktop.
+    Supports: click, type, key, scroll, screenshot, move.
+    Returns a result dict.
+    """
+    action_type = action.get("action")
+    display_env = {**os.environ, "DISPLAY": ":1"}
+
+    try:
+        if action_type == "screenshot":
+            return {"type": "screenshot", "status": "ok"}
+
+        elif action_type == "click":
+            x = action.get("coordinate", [0, 0])[0]
+            y = action.get("coordinate", [0, 0])[1]
+            button = action.get("button", "left")
+            btn_flag = {"left": "1", "right": "3", "middle": "2"}.get(button, "1")
+            subprocess.run(
+                ["xdotool", "mousemove", str(x), str(y), "click", btn_flag],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "click", "x": x, "y": y, "button": button, "status": "ok"}
+
+        elif action_type == "double_click":
+            x = action.get("coordinate", [0, 0])[0]
+            y = action.get("coordinate", [0, 0])[1]
+            subprocess.run(
+                ["xdotool", "mousemove", str(x), str(y),
+                 "click", "--repeat", "2", "--delay", "100", "1"],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "double_click", "x": x, "y": y, "status": "ok"}
+
+        elif action_type == "type":
+            text = action.get("text", "")
+            subprocess.run(
+                ["xdotool", "type", "--clearmodifiers", "--delay", "25", text],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "type", "text": text[:50], "status": "ok"}
+
+        elif action_type == "key":
+            key = action.get("key", "")
+            subprocess.run(
+                ["xdotool", "key", key],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "key", "key": key, "status": "ok"}
+
+        elif action_type == "scroll":
+            x = action.get("coordinate", [640, 400])[0]
+            y = action.get("coordinate", [640, 400])[1]
+            direction = action.get("direction", "down")
+            amount = action.get("amount", 3)
+            btn = "5" if direction == "down" else "4"
+            subprocess.run(
+                ["xdotool", "mousemove", str(x), str(y)],
+                env=display_env, check=True, capture_output=True,
+            )
+            for _ in range(amount):
+                subprocess.run(
+                    ["xdotool", "click", btn],
+                    env=display_env, check=True, capture_output=True,
+                )
+            return {"type": "scroll", "direction": direction, "amount": amount, "status": "ok"}
+
+        elif action_type == "move":
+            x = action.get("coordinate", [0, 0])[0]
+            y = action.get("coordinate", [0, 0])[1]
+            subprocess.run(
+                ["xdotool", "mousemove", str(x), str(y)],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "move", "x": x, "y": y, "status": "ok"}
+
+        elif action_type == "wait":
+            duration = action.get("duration", 2)
+            import time
+            time.sleep(duration)
+            return {"type": "wait", "duration": duration, "status": "ok"}
+
+        else:
+            return {"type": action_type, "status": "unsupported"}
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Action execution failed: {action_type} — {e}")
+        return {"type": action_type, "status": "error", "msg": str(e)}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VERTEX AI COMPUTER USE API CALL
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def call_claude_computer_use(
+    messages: list,
+    system_prompt: str,
+) -> dict:
+    """
+    Call Claude Sonnet 4.6 on Vertex AI with computer use tools.
+    Uses the rawPredict endpoint with the computer-use beta header.
+    """
+    token = get_access_token()
+
+    payload = {
+        "anthropic_version": "vertex-2023-10-16",
+        "max_tokens": 4096,
+        "system": system_prompt,
+        "messages": messages,
+        "tools": [
+            {
+                "type": "computer_20250124",
+                "name": "computer",
+                "display_width_px": DISPLAY_WIDTH,
+                "display_height_px": DISPLAY_HEIGHT,
+                "display_number": 1,
+            }
+        ],
+        "betas": [BETA_HEADER],
+    }
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            VERTEX_ENDPOINT,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# AGENT LOOP
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def build_system_prompt(deal_package: dict) -> str:
+    """Build the system prompt with deal package context for the browser agent."""
+    return f"""You are a Salesforce operations agent. Your job is to create a new
+Opportunity in Salesforce Lightning using the deal package data provided below.
+
+DEAL PACKAGE:
+- Client Name: {deal_package.get('client_name', 'Unknown')}
+- AUM: ${deal_package.get('aum_millions', 0)}M
+- Strategy: {deal_package.get('strategy', 'Unknown')}
+- Mandate Type: {deal_package.get('mandate_type', 'Unknown')}
+- Fee Structure: {deal_package.get('fee_structure', 'Unknown')}
+- Compliance Status: {deal_package.get('compliance_status', 'Unknown')}
+- Risk Tier: {deal_package.get('risk_tier', 'Unknown')}
+- Primary Contact: {deal_package.get('primary_contact', 'Unknown')}
+- Primary Contact Title: {deal_package.get('primary_contact_title', 'Unknown')}
+- Deal ID: {deal_package.get('deal_id', 'Unknown')}
+
+SALESFORCE URL: {SALESFORCE_URL}
+
+INSTRUCTIONS:
+1. You should see the Salesforce Lightning interface in the browser.
+2. Navigate to the Sales app if not already there.
+3. Click "New" to create a new Opportunity.
+4. Fill in these fields:
+   - Opportunity Name: "{deal_package.get('client_name', 'Unknown')} — {deal_package.get('mandate_type', 'New Mandate')}"
+   - Close Date: Set to 30 days from today
+   - Stage: "Negotiation"
+   - Amount: {deal_package.get('aum_millions', 0)}000000
+5. Fill in any additional fields visible on the form.
+6. Click Save.
+7. After saving, take a screenshot to verify the Opportunity was created.
+8. Report the Opportunity name and any ID visible on the page.
+
+IMPORTANT:
+- Work carefully and methodically.
+- If a page is loading, wait a moment and take another screenshot.
+- If you encounter an error, try an alternative approach.
+- Do NOT navigate away from Salesforce.
+- When you are done, include the text "TASK_COMPLETE" in your response."""
+
+
+async def run_salesforce_agent(
+    deal_package: dict,
+) -> AsyncGenerator[dict, None]:
+    """
+    Run the Salesforce browser agent loop.
+    Yields SSE-compatible event dicts as the agent progresses.
+    """
+    system_prompt = build_system_prompt(deal_package)
+    messages = []
+    iteration = 0
+
+    yield {
+        "type": "agent_start",
+        "agent": "salesforce_agent",
+        "msg": "Browser agent activating — connecting to Salesforce...",
+    }
+
+    # Take initial screenshot
+    try:
+        screenshot_b64 = take_screenshot()
+    except Exception as e:
+        yield {
+            "type": "error",
+            "agent": "salesforce_agent",
+            "msg": f"Failed to capture initial screenshot: {e}",
+        }
+        return
+
+    # Start conversation with initial screenshot
+    messages.append({
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": "Here is the current state of the screen. Please create the Salesforce Opportunity using the deal package data.",
+            },
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": screenshot_b64,
+                },
+            },
+        ],
+    })
+
+    yield {
+        "type": "tool_call",
+        "agent": "salesforce_agent",
+        "tool": "screenshot",
+        "msg": "Captured Salesforce dashboard",
+    }
+
+    while iteration < MAX_ITERATIONS:
+        iteration += 1
+        logger.info(f"Salesforce agent — iteration {iteration}")
+
+        # Call Claude with current conversation
+        try:
+            response = await call_claude_computer_use(messages, system_prompt)
+        except Exception as e:
+            yield {
+                "type": "error",
+                "agent": "salesforce_agent",
+                "msg": f"Vertex AI call failed: {e}",
+            }
+            return
+
+        # Process response content blocks
+        assistant_content = response.get("content", [])
+        messages.append({"role": "assistant", "content": assistant_content})
+
+        # Check for task completion or tool use
+        has_tool_use = False
+        task_complete = False
+        tool_results = []
+
+        for block in assistant_content:
+            block_type = block.get("type")
+
+            if block_type == "text":
+                text = block.get("text", "")
+                if "TASK_COMPLETE" in text:
+                    task_complete = True
+                    yield {
+                        "type": "agent_output",
+                        "agent": "salesforce_agent",
+                        "msg": text[:500],
+                    }
+
+            elif block_type == "tool_use":
+                has_tool_use = True
+                tool_input = block.get("input", {})
+                tool_id = block.get("id")
+                action_type = tool_input.get("action", "unknown")
+
+                # Emit event for the frontend
+                action_desc = _describe_action(tool_input)
+                yield {
+                    "type": "tool_call",
+                    "agent": "salesforce_agent",
+                    "tool": "computer_use",
+                    "msg": action_desc,
+                }
+
+                # Execute the action
+                result = execute_action(tool_input)
+
+                # Small delay for UI responsiveness
+                await asyncio.sleep(0.5)
+
+                # Take a new screenshot after the action
+                try:
+                    screenshot_b64 = take_screenshot()
+                except Exception as e:
+                    logger.error(f"Screenshot failed: {e}")
+                    screenshot_b64 = None
+
+                # Build tool result
+                tool_result_content = []
+                if screenshot_b64:
+                    tool_result_content.append({
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": screenshot_b64,
+                        },
+                    })
+
+                if result.get("status") == "error":
+                    tool_result_content.append({
+                        "type": "text",
+                        "text": f"Action failed: {result.get('msg', 'unknown error')}",
+                    })
+
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tool_id,
+                    "content": tool_result_content,
+                })
+
+                yield {
+                    "type": "tool_result",
+                    "agent": "salesforce_agent",
+                    "tool": "computer_use",
+                    "msg": f"Action executed: {action_type} — {result.get('status')}",
+                }
+
+        if task_complete:
+            yield {
+                "type": "agent_complete",
+                "agent": "salesforce_agent",
+                "msg": "Salesforce Opportunity created and verified",
+            }
+            return
+
+        if has_tool_use and tool_results:
+            messages.append({"role": "user", "content": tool_results})
+        elif not has_tool_use:
+            # Model responded with text only, no tool use — done
+            yield {
+                "type": "agent_complete",
+                "agent": "salesforce_agent",
+                "msg": "Salesforce agent finished",
+            }
+            return
+
+    # Max iterations reached
+    yield {
+        "type": "agent_complete",
+        "agent": "salesforce_agent",
+        "msg": f"Max iterations ({MAX_ITERATIONS}) reached — review Salesforce manually",
+    }
+
+
+def _describe_action(tool_input: dict) -> str:
+    """Create a human-readable description of a computer use action."""
+    action = tool_input.get("action", "unknown")
+
+    if action == "click":
+        coords = tool_input.get("coordinate", [0, 0])
+        return f"Click at ({coords[0]}, {coords[1]})"
+
+    elif action == "double_click":
+        coords = tool_input.get("coordinate", [0, 0])
+        return f"Double-click at ({coords[0]}, {coords[1]})"
+
+    elif action == "type":
+        text = tool_input.get("text", "")
+        display = text[:60] + "..." if len(text) > 60 else text
+        return f'Type: "{display}"'
+
+    elif action == "key":
+        return f"Press key: {tool_input.get('key', '')}"
+
+    elif action == "scroll":
+        direction = tool_input.get("direction", "down")
+        return f"Scroll {direction}"
+
+    elif action == "screenshot":
+        return "Capture screenshot"
+
+    elif action == "move":
+        coords = tool_input.get("coordinate", [0, 0])
+        return f"Move cursor to ({coords[0]}, {coords[1]})"
+
+    elif action == "wait":
+        return f"Wait {tool_input.get('duration', 2)}s for page load"
+
+    return f"Action: {action}"

--- a/03-demos/deal-desk-agent/backend/main.py
+++ b/03-demos/deal-desk-agent/backend/main.py
@@ -1,0 +1,1451 @@
+"""
+Deal Desk Agent — FastAPI backend.
+Serves the ADK pipeline with SSE streaming for real-time agent events.
+Deployed on Cloud Run, backed by Claude on Vertex AI.
+"""
+
+import os
+import json
+import asyncio
+import httpx
+import logging
+from datetime import datetime, timezone
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse, JSONResponse, FileResponse
+from google.cloud import bigquery
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.sessions import VertexAiSessionService
+from google.genai import types
+
+from agents import deal_desk_pipeline
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONFIG
+# ═══════════════════════════════════════════════════════════════════════════════
+
+PROJECT_ID = os.environ.get("PROJECT_ID", "cpe-slarbi-nvd-ant-demos")
+DATASET = os.environ.get("BQ_DATASET", "deal_desk_agent")
+REGION = os.environ.get("REGION", "us-east5")
+PORT = int(os.environ.get("PORT", 8080))
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("deal-desk-agent")
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ADK RUNNER SETUP
+# ═══════════════════════════════════════════════════════════════════════════════
+
+session_service = InMemorySessionService()
+
+runner = Runner(
+    agent=deal_desk_pipeline,
+    app_name="deal_desk_agent",
+    session_service=session_service,
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FASTAPI APP
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info(f"Deal Desk Agent starting — project={PROJECT_ID}, region={REGION}")
+    logger.info(f"Model provider: {os.environ.get('MODEL_PROVIDER', 'claude')}")
+    yield
+    logger.info("Deal Desk Agent shutting down")
+
+app = FastAPI(
+    title="Deal Desk Agent",
+    description="FSI Deal Desk pipeline — Anthropic + Google Cloud Better Together",
+    version="1.0.0",
+    lifespan=lifespan,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SSE EVENT HELPERS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def sse_event(event_type: str, data: dict) -> str:
+    """Format a Server-Sent Event."""
+    payload = json.dumps({
+        "type": event_type,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        **data,
+    })
+    return f"event: {event_type}\ndata: {payload}\n\n"
+
+
+def classify_event(event):
+    """
+    Classify an ADK event into a frontend-friendly event type.
+    Returns (event_type, event_data) tuple.
+    """
+    agent_name = getattr(event, "author", None) or "unknown"
+    actions = getattr(event, "actions", None)
+
+    # Check for tool calls in the event content
+    if hasattr(event, "content") and event.content:
+        content = event.content
+
+        # Tool call events
+        if hasattr(content, "parts"):
+            for part in content.parts:
+                if hasattr(part, "function_call") and part.function_call:
+                    fc = part.function_call
+                    return "tool_call", {
+                        "agent": agent_name,
+                        "tool": fc.name,
+                        "args": dict(fc.args) if fc.args else {},
+                        "msg": f"Calling {fc.name}",
+                    }
+                if hasattr(part, "function_response") and part.function_response:
+                    fr = part.function_response
+                    response_data = dict(fr.response) if fr.response else {}
+                    # Truncate large responses for the frontend
+                    summary = _summarize_tool_response(fr.name, response_data)
+                    return "tool_result", {
+                        "agent": agent_name,
+                        "tool": fr.name,
+                        "msg": summary,
+                    }
+
+
+
+
+
+
+    # Only emit agent text output for final responses (prevents duplicates)
+    if hasattr(event, "is_final_response") and event.is_final_response():
+        if hasattr(event, "content") and event.content and hasattr(event.content, "parts"):
+            all_text = " ".join(
+                part.text for part in event.content.parts
+                if hasattr(part, "text") and part.text
+                and not (hasattr(part, "function_call") and part.function_call)
+                and not (hasattr(part, "function_response") and part.function_response)
+            ).strip()
+            if all_text:
+                return "agent_output", {
+                    "agent": agent_name,
+                    "msg": all_text[:4000],
+                }
+
+    # Agent transfer / completion signals
+    if actions:
+        if getattr(actions, "escalate", False):
+            return "agent_complete", {
+                "agent": agent_name,
+                "msg": "Agent completed",
+            }
+        if getattr(actions, "transfer_to_agent", None):
+            return "agent_transfer", {
+                "agent": agent_name,
+                "target": actions.transfer_to_agent,
+                "msg": f"Transferring to {actions.transfer_to_agent}",
+            }
+
+    return None, None
+
+
+def _summarize_tool_response(tool_name: str, response: dict) -> str:
+    """Create a concise summary of a tool response for the frontend."""
+    if tool_name == "query_client_data":
+        found = response.get("found", False)
+        count = response.get("match_count", 0)
+        return f"{'Found' if found else 'No'} client records ({count} matches)" if found else "No matching client records"
+
+    if tool_name == "query_market_intelligence":
+        count = response.get("record_count", 0)
+        return f"Retrieved {count} market intelligence records"
+
+    if tool_name == "query_compliance_records":
+        found = response.get("found", False)
+        records = response.get("records", [])
+        if records:
+            kyc = records[0].get("kyc_status", "UNKNOWN")
+            sanctions = records[0].get("sanctions_status", "UNKNOWN")
+            return f"KYC: {kyc} | Sanctions: {sanctions}"
+        return "No compliance records found"
+
+    if tool_name == "compute_risk_score":
+        tier = response.get("risk_tier", "UNKNOWN")
+        score = response.get("risk_score", 0)
+        return f"Risk Tier: {tier} | Score: {score}"
+
+    if tool_name == "insert_deal_package":
+        deal_id = response.get("deal_id", "UNKNOWN")
+        return f"Deal logged: {deal_id}"
+
+    if tool_name == "update_client_status":
+        status = response.get("new_status", "UNKNOWN")
+        return f"Client status updated to {status}"
+
+    return json.dumps(response, default=str)[:200]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ROUTES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@app.get("/api/health")
+async def health():
+    """Health check for Cloud Run."""
+    return {
+        "status": "healthy",
+        "service": "deal-desk-agent",
+        "project": PROJECT_ID,
+        "region": REGION,
+        "model_provider": os.environ.get("MODEL_PROVIDER", "claude"),
+    }
+
+
+# Old agent card endpoint removed — replaced by A2A handler below
+
+
+@app.post("/api/run")
+async def run_pipeline(request: Request):
+    """
+    Execute the Deal Desk pipeline and stream events via SSE.
+    Accepts JSON body with 'prompt' field.
+    Returns a stream of typed events for the frontend.
+    """
+    body = await request.json()
+    prompt = body.get("prompt", "")
+
+    if not prompt:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "prompt is required"},
+        )
+
+    logger.info(f"Pipeline started — prompt: {prompt[:100]}...")
+
+    async def event_stream():
+        # Emit pipeline start
+        yield sse_event("pipeline_start", {
+            "msg": "Deal Desk pipeline activated",
+            "prompt": prompt[:200],
+        })
+
+        try:
+            # Create a session for this run
+            session = await session_service.create_session(
+                app_name="deal_desk_agent",
+                user_id="booth-demo",
+            )
+
+            # Build the user message
+            user_content = types.Content(
+                role="user",
+                parts=[types.Part(text=prompt)],
+            )
+
+            # Track which agents we've seen start
+            seen_agents = set()
+
+            # Run the pipeline and stream events
+            async for event in runner.run_async(
+                user_id="booth-demo",
+                session_id=session.id,
+                new_message=user_content,
+            ):
+                agent_name = getattr(event, "author", None)
+
+                # Emit agent_start on first event from each agent
+                if agent_name and agent_name not in seen_agents:
+                    seen_agents.add(agent_name)
+                    yield sse_event("agent_start", {
+                        "agent": agent_name,
+                        "msg": f"{agent_name} activating...",
+                    })
+
+                # Classify and emit the event
+                event_type, event_data = classify_event(event)
+                if event_type and event_data:
+                    yield sse_event(event_type, event_data)
+
+                    # If synthesis agent outputs, also emit deal_package
+                    if (event_type == "agent_output"
+                            and agent_name == "synthesis_agent"):
+                        yield sse_event("deal_package", {
+                            "agent": agent_name,
+                            "msg": event_data.get("msg", ""),
+                        })
+
+            # ─── Trigger Salesforce Browser Agent on GCE VM ───
+            BROWSER_AGENT_URL = os.environ.get(
+                "BROWSER_AGENT_URL", "http://35.223.98.125:8090"
+            )
+            try:
+                # Extract deal package from session state
+                session_state = session.state or {}
+                deal_output = session_state.get("deal_package", "")
+
+                # Build deal package by looking up client in BigQuery (proven approach)
+                import re as regex
+
+                # Step 1: Find the client name from prompt or synthesis output
+                _all_text = prompt + "\n" + str(deal_output or "")
+                _client_match = None
+
+                # Try known company suffixes first
+                _name_patterns = [
+                    r"(?:onboard|for|about)\s+([A-Z][A-Za-z\s&]+(?:Capital|Fund|Advisors|Partners|Management|Group|LLC|Research|Investment))",
+                    r"Client(?:\s+Name)?[:\|]\s*([^\n|]+)",
+                ]
+                for _pat in _name_patterns:
+                    _m = regex.search(_pat, _all_text, regex.IGNORECASE)
+                    if _m:
+                        _client_match = _m.group(1).strip().strip("*").strip()
+                        break
+
+                logger.info(f"SF agent — extracted client name: {_client_match} from prompt: {prompt[:80]}")
+
+                # Step 2: Look up in BigQuery for real data
+                deal_package = None
+                if _client_match:
+                    try:
+                        from google.cloud import bigquery as _bq_pipe
+                        _bq_c = _bq_pipe.Client(project=PROJECT_ID)
+                        _rows = list(_bq_c.query(f"""
+                            SELECT name, aum_millions, strategy, fee_structure,
+                                   primary_contact, primary_contact_title
+                            FROM `{PROJECT_ID}.{DATASET}.clients`
+                            WHERE LOWER(name) LIKE LOWER(@s) LIMIT 1
+                        """, job_config=_bq_pipe.QueryJobConfig(
+                            query_parameters=[_bq_pipe.ScalarQueryParameter("s", "STRING", f"%{_client_match}%")]
+                        )).result())
+                        if _rows:
+                            _r = _rows[0]
+                            deal_package = {
+                                "client_name": _r.name,
+                                "aum_millions": float(_r.aum_millions or 0),
+                                "strategy": _r.strategy or "Unknown",
+                                "mandate_type": f"{_r.strategy or 'New'} Mandate",
+                                "fee_structure": _r.fee_structure or "TBD",
+                                "compliance_status": "CLEARED",
+                                "risk_tier": "MEDIUM",
+                                "primary_contact": _r.primary_contact or "Unknown",
+                                "primary_contact_title": _r.primary_contact_title or "Unknown",
+                                "deal_id": f"DEAL-{datetime.now(timezone.utc).strftime('%H%M%S')}",
+                            }
+                            logger.info(f"SF deal_package from BigQuery: {deal_package['client_name']} ${deal_package['aum_millions']}M")
+                    except Exception as _bq_err:
+                        logger.warning(f"BQ lookup failed: {_bq_err}")
+
+                # Step 3: Fallback if BQ lookup failed
+                if not deal_package:
+                    deal_package = {
+                        "client_name": _client_match or "Unknown Client",
+                        "aum_millions": 0.0,
+                        "strategy": "Unknown",
+                        "mandate_type": "New Mandate",
+                        "fee_structure": "TBD",
+                        "compliance_status": "PENDING",
+                        "risk_tier": "PENDING",
+                        "primary_contact": "Unknown",
+                        "primary_contact_title": "Unknown",
+                        "deal_id": f"DEAL-{datetime.now(timezone.utc).strftime('%H%M%S')}",
+                    }
+
+                logger.info(f"Triggering Salesforce agent for: {deal_package.get('client_name')}")
+
+                import httpx
+                async with httpx.AsyncClient(timeout=300.0) as http_client:
+                    async with http_client.stream(
+                        "POST",
+                        f"{BROWSER_AGENT_URL}/run",
+                        json={"deal_package": deal_package},
+                        headers={"X-Agent-Secret": os.environ.get("AGENT_SECRET", "")},
+                    ) as sf_response:
+                        buffer = ""
+                        async for chunk in sf_response.aiter_text():
+                            buffer += chunk
+                            lines = buffer.split("\n")
+                            buffer = lines.pop()
+                            for line in lines:
+                                if line.startswith("data: "):
+                                    try:
+                                        evt = json.loads(line[6:])
+                                        yield sse_event(
+                                            evt.get("type", "agent_event"),
+                                            {
+                                                "agent": evt.get("agent", "salesforce_agent"),
+                                                "tool": evt.get("tool", ""),
+                                                "msg": evt.get("msg", ""),
+                                            }
+                                        )
+                                    except json.JSONDecodeError:
+                                        pass
+            except Exception as sf_err:
+                logger.error(f"Salesforce agent error: {sf_err}", exc_info=True)
+                yield sse_event("error", {
+                    "agent": "salesforce_agent",
+                    "msg": f"Salesforce agent error: {str(sf_err)}",
+                })
+
+            # Emit pipeline complete
+            yield sse_event("pipeline_complete", {
+                "msg": "Deal Desk pipeline complete — including Salesforce entry",
+                "agents_used": list(seen_agents) + ["salesforce_agent"],
+            })
+
+        except Exception as e:
+            logger.error(f"Pipeline error: {e}", exc_info=True)
+            yield sse_event("error", {
+                "msg": f"Pipeline error: {str(e)}",
+            })
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONVERSATIONAL AGENT — Claude with Tool Access
+# ═══════════════════════════════════════════════════════════════════════════════
+
+import google.auth
+import google.auth.transport.requests
+
+CHAT_MODEL = os.environ.get("SONNET_MODEL", "claude-sonnet-4-6@default")
+CHAT_ENDPOINT = (
+    f"https://{REGION}-aiplatform.googleapis.com/v1/"
+    f"projects/{PROJECT_ID}/locations/{REGION}/"
+    f"publishers/anthropic/models/{CHAT_MODEL}:rawPredict"
+)
+
+SYSTEM_PROMPT = """You are the **Deal Desk Agent**, a professional AI assistant for financial services deal management. You work at an institutional investment firm and help portfolio managers, compliance officers, and operations teams manage client onboarding and deal flow.
+
+You are powered by **Claude AI on Google Cloud Vertex AI**, orchestrated by the **Agent Development Kit (ADK)**, with data stored in **BigQuery** and CRM integration via **Salesforce**.
+
+## Your Capabilities
+
+You have direct access to these data tools:
+- **query_clients** — Search and list client records from BigQuery (name, AUM, strategy, status, contacts)
+- **query_compliance** — Look up KYC, AML, sanctions, and FINRA compliance records
+- **query_intelligence** — Pull market intelligence: SEC filings, news, and research
+- **query_deals** — View recent deal packages processed by the pipeline
+
+You also have these action tools:
+- **run_deal_pipeline** — Run the full Deal Desk pipeline: parallel research + compliance checks, risk scoring, synthesis, and automatic Salesforce Opportunity creation. Use this when someone wants to ONBOARD a new client or run a full deal process.
+- **create_salesforce_opportunity** — Create a Salesforce Opportunity directly for a known client, without the full pipeline.
+
+## How You Behave
+
+- Be warm, professional, and concise — you're talking to senior financial professionals
+- When someone asks about data, USE YOUR TOOLS to query BigQuery — don't say you can't access data
+- When someone wants to onboard a client, use run_deal_pipeline
+- IMPORTANT: If the user says "thank you", "thanks", "ok", "done", "got it", "great", or any short acknowledgment, DO NOT trigger any tools. Just respond warmly. These are NOT requests to run the pipeline again.
+- NEVER re-trigger run_deal_pipeline or create_salesforce_opportunity if it was already called in this conversation, unless the user explicitly names a DIFFERENT client
+- IMPORTANT: If the user says "thank you", "thanks", "ok", "done", "got it", "great", or any short acknowledgment, DO NOT trigger any tools. Just respond warmly. These are NOT requests to run the pipeline again.
+- NEVER re-trigger run_deal_pipeline or create_salesforce_opportunity if it was already called in this conversation, unless the user explicitly names a DIFFERENT client
+- When someone just wants a Salesforce entry, use create_salesforce_opportunity
+- Format data cleanly with tables when showing results
+- After completing any task, ask if there's anything else you can help with
+- When someone says goodbye, thank them professionally
+- If someone asks about capabilities, explain naturally — don't list raw tool names
+- Guide users naturally: if they seem unsure, suggest what you can do
+- You can discuss FSI topics, market trends, compliance concepts — you're knowledgeable
+- Always mention the Google Cloud services powering you when relevant (BigQuery, Vertex AI, ADK)
+"""
+
+TOOLS = [
+    {
+        "name": "query_clients",
+        "description": "Search and list client records from BigQuery. Use with no parameters to list all clients, or provide a client_name to search for a specific client.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "client_name": {"type": "string", "description": "Optional: client name to search for. Leave empty to list all clients."}
+            }
+        }
+    },
+    {
+        "name": "query_compliance",
+        "description": "Look up compliance records from BigQuery: KYC status, AML screening, sanctions checks, FINRA registration. Provide a client_name to get their compliance data, or leave empty for an overview of all clients.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "client_name": {"type": "string", "description": "Optional: client name to look up compliance for."}
+            }
+        }
+    },
+    {
+        "name": "query_intelligence",
+        "description": "Pull market intelligence from BigQuery: SEC filings, news articles, research notes. Requires a client_name.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "client_name": {"type": "string", "description": "Client name to search intelligence for."}
+            },
+            "required": ["client_name"]
+        }
+    },
+    {
+        "name": "query_deals",
+        "description": "View recent deal packages that have been processed by the pipeline. Shows deal ID, client, status, risk tier, and creation time.",
+        "input_schema": {
+            "type": "object",
+            "properties": {}
+        }
+    },
+    {
+        "name": "run_deal_pipeline",
+        "description": "Run the FULL Deal Desk pipeline for client onboarding. This triggers: parallel research + compliance agents, risk scoring, deal package synthesis, and automatic Salesforce Opportunity creation. Use this when someone explicitly wants to onboard a client or run the full pipeline.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "The full onboarding request to pass to the pipeline."}
+            },
+            "required": ["prompt"]
+        }
+    },
+    {
+        "name": "create_salesforce_opportunity",
+        "description": "Create a Salesforce Opportunity directly for a known client. Looks up the client in BigQuery and triggers the browser agent to create the Opportunity in Salesforce.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "client_name": {"type": "string", "description": "The client name to create an opportunity for."}
+            },
+            "required": ["client_name"]
+        }
+    }
+]
+
+
+def _get_token():
+    creds, _ = google.auth.default()
+    creds.refresh(google.auth.transport.requests.Request())
+    return creds.token
+
+
+def _execute_tool(tool_name, tool_input):
+    """Execute a tool and return the result as a string."""
+    from google.cloud import bigquery as bq_mod
+    bq = bq_mod.Client(project=PROJECT_ID)
+
+    if tool_name == "query_clients":
+        client_name = tool_input.get("client_name", "")
+        if client_name:
+            rows = list(bq.query(f"""
+                SELECT name, aum_millions, strategy, domicile, fee_structure, 
+                       relationship_status, primary_contact, primary_contact_title, onboard_date
+                FROM `{PROJECT_ID}.{DATASET}.clients`
+                WHERE LOWER(name) LIKE LOWER(@s)
+                ORDER BY aum_millions DESC
+            """, job_config=bq_mod.QueryJobConfig(
+                query_parameters=[bq_mod.ScalarQueryParameter("s", "STRING", f"%{client_name}%")]
+            )).result())
+        else:
+            rows = list(bq.query(f"""
+                SELECT name, aum_millions, strategy, domicile, fee_structure,
+                       relationship_status, primary_contact, primary_contact_title
+                FROM `{PROJECT_ID}.{DATASET}.clients`
+                ORDER BY aum_millions DESC
+            """).result())
+        return json.dumps([dict(r) for r in rows], default=str)
+
+    elif tool_name == "query_compliance":
+        client_name = tool_input.get("client_name", "")
+        if client_name:
+            rows = list(bq.query(f"""
+                SELECT * FROM `{PROJECT_ID}.{DATASET}.compliance_records`
+                WHERE LOWER(client_name) LIKE LOWER(@s)
+            """, job_config=bq_mod.QueryJobConfig(
+                query_parameters=[bq_mod.ScalarQueryParameter("s", "STRING", f"%{client_name}%")]
+            )).result())
+        else:
+            rows = list(bq.query(f"""
+                SELECT client_name, kyc_status, aml_status, sanctions_status, risk_tier
+                FROM `{PROJECT_ID}.{DATASET}.compliance_records`
+                ORDER BY risk_tier
+            """).result())
+        return json.dumps([dict(r) for r in rows], default=str)
+
+    elif tool_name == "query_intelligence":
+        client_name = tool_input.get("client_name", "")
+        rows = list(bq.query(f"""
+            SELECT source, intel_type, summary, date, relevance_score
+            FROM `{PROJECT_ID}.{DATASET}.market_intelligence`
+            WHERE LOWER(client_name) LIKE LOWER(@s)
+            ORDER BY relevance_score DESC LIMIT 5
+        """, job_config=bq_mod.QueryJobConfig(
+            query_parameters=[bq_mod.ScalarQueryParameter("s", "STRING", f"%{client_name}%")]
+        )).result())
+        return json.dumps([dict(r) for r in rows], default=str)
+
+    elif tool_name == "query_deals":
+        rows = list(bq.query(f"""
+            SELECT deal_id, client_name, aum_millions, status, risk_tier, compliance_status, created_at
+            FROM `{PROJECT_ID}.{DATASET}.deal_packages`
+            ORDER BY created_at DESC LIMIT 10
+        """).result())
+        return json.dumps([dict(r) for r in rows], default=str)
+
+    elif tool_name == "run_deal_pipeline":
+        return "TRIGGER_PIPELINE"
+
+    elif tool_name == "create_salesforce_opportunity":
+        return "TRIGGER_SALESFORCE"
+
+    return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+
+# Persistent conversation memory via Agent Engine Memory Bank
+AGENT_ENGINE_ID = os.environ.get("AGENT_ENGINE_ID", "546572177969774592")
+_memory_session_service = VertexAiSessionService(
+    project=PROJECT_ID,
+    location="us-central1",
+    agent_engine_id=AGENT_ENGINE_ID,
+)
+_conversations = {}  # Local cache, backed by Agent Engine
+
+
+@app.post("/api/chat")
+async def chat(request: Request):
+    body = await request.json()
+    message = body.get("prompt", "")
+    session_id = body.get("session_id", "default")
+
+    if not message:
+        return JSONResponse(status_code=400, content={"error": "prompt is required"})
+
+    logger.info(f"Chat: {message[:100]}...")
+
+    # Get or create conversation history
+    if session_id not in _conversations:
+        _conversations[session_id] = []
+    history = _conversations[session_id]
+
+    # Add user message
+    history.append({"role": "user", "content": message})
+
+    # Keep last 20 messages to manage context
+    if len(history) > 20:
+        history = history[-20:]
+        _conversations[session_id] = history
+
+    async def event_stream():
+        try:
+            # Conversation loop with tool use
+            messages = list(history)
+            max_turns = 10
+
+            for turn in range(max_turns):
+                # Call Claude
+                async with httpx.AsyncClient(timeout=120.0) as client:
+                    resp = await client.post(
+                        CHAT_ENDPOINT,
+                        headers={
+                            "Authorization": f"Bearer {_get_token()}",
+                            "Content-Type": "application/json",
+                        },
+                        json={
+                            "anthropic_version": "vertex-2023-10-16",
+                            "max_tokens": 4096,
+                            "system": SYSTEM_PROMPT,
+                            "messages": messages,
+                            "tools": TOOLS,
+                        },
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+
+                content_blocks = data.get("content", [])
+                stop_reason = data.get("stop_reason", "end_turn")
+
+                # Add assistant response to history
+                messages.append({"role": "assistant", "content": content_blocks})
+
+                # Check if Claude wants to use tools
+                if stop_reason == "tool_use":
+                    tool_results = []
+                    for block in content_blocks:
+                        if block.get("type") == "text" and block.get("text", "").strip():
+                            yield sse_event("chat_response", {
+                                "agent": "deal_desk_agent",
+                                "msg": block["text"],
+                            })
+                        elif block.get("type") == "tool_use":
+                            tool_name = block["name"]
+                            tool_input = block.get("input", {})
+                            tool_id = block["id"]
+
+                            logger.info(f"Tool call: {tool_name}({json.dumps(tool_input)[:100]})")
+
+                            # Emit tool call event
+                            yield sse_event("tool_call", {
+                                "agent": "deal_desk_agent",
+                                "tool": tool_name,
+                                "msg": f"Querying {tool_name.replace('_', ' ')}...",
+                            })
+
+                            # Execute tool
+                            result = _execute_tool(tool_name, tool_input)
+
+                            # Handle special triggers
+                            if result == "TRIGGER_PIPELINE":
+                                yield sse_event("tool_result", {
+                                    "agent": "deal_desk_agent",
+                                    "tool": tool_name,
+                                    "msg": "Starting Deal Desk pipeline...",
+                                })
+
+                                # Run the full ADK pipeline
+                                prompt = tool_input.get("prompt", message)
+                                session = await session_service.create_session(
+                                    app_name="deal_desk_agent",
+                                    user_id="booth-demo",
+                                )
+                                user_content = types.Content(
+                                    role="user",
+                                    parts=[types.Part(text=prompt)],
+                                )
+                                seen_agents = set()
+                                async for event in runner.run_async(
+                                    user_id="booth-demo",
+                                    session_id=session.id,
+                                    new_message=user_content,
+                                ):
+                                    agent_name = getattr(event, "author", None)
+                                    if agent_name and agent_name not in seen_agents:
+                                        seen_agents.add(agent_name)
+                                        yield sse_event("agent_start", {
+                                            "agent": agent_name,
+                                            "msg": f"{agent_name} activating...",
+                                        })
+                                    event_type, event_data = classify_event(event)
+                                    if event_type and event_data:
+                                        yield sse_event(event_type, event_data)
+
+                                # Trigger Salesforce
+                                BROWSER_AGENT_URL = os.environ.get("BROWSER_AGENT_URL", "http://35.223.98.125:8090")
+                                try:
+                                    # Extract client name from the message and look up in BigQuery
+                                    import re as regex2
+                                    _client_name_for_sf = None
+
+                                    # Try to find client name in the user message
+                                    _cn_patterns = [
+                                        r"(?:onboard|opportunity|salesforce|SF|enter|create|for|about)\s+(?:new\s+client:?\s+)?([A-Z][A-Za-z\s&]+(?:Capital|Fund|Advisors|Partners|Management|Group|LLC|Research|Investment))",
+                                        r"([A-Z][A-Za-z\s&]+(?:Capital|Fund|Advisors|Partners|Management|Group|LLC|Research|Investment))",
+                                    ]
+                                    for _cp in _cn_patterns:
+                                        _cm = regex2.search(_cp, message, regex2.IGNORECASE)
+                                        if _cm:
+                                            _client_name_for_sf = _cm.group(1).strip()
+                                            break
+
+                                    # Look up in BigQuery for real data
+                                    deal_pkg = {
+                                        "client_name": _client_name_for_sf or "Unknown Client",
+                                        "aum_millions": 0.0,
+                                        "strategy": "Unknown",
+                                        "mandate_type": "New Mandate",
+                                        "fee_structure": "TBD",
+                                        "compliance_status": "PENDING",
+                                        "risk_tier": "PENDING",
+                                        "primary_contact": "Unknown",
+                                        "primary_contact_title": "Unknown",
+                                        "deal_id": f"DEAL-{datetime.now(timezone.utc).strftime('%H%M%S')}",
+                                    }
+
+                                    if _client_name_for_sf:
+                                        try:
+                                            from google.cloud import bigquery as _bq_sf
+                                            _bq_c = _bq_sf.Client(project=PROJECT_ID)
+                                            _bq_rows = list(_bq_c.query(f"""
+                                                SELECT name, aum_millions, strategy, fee_structure,
+                                                       primary_contact, primary_contact_title,
+                                                       relationship_status
+                                                FROM `{PROJECT_ID}.{DATASET}.clients`
+                                                WHERE LOWER(name) LIKE LOWER(@s)
+                                                LIMIT 1
+                                            """, job_config=_bq_sf.QueryJobConfig(
+                                                query_parameters=[_bq_sf.ScalarQueryParameter("s", "STRING", f"%{_client_name_for_sf}%")]
+                                            )).result())
+                                            if _bq_rows:
+                                                _r = _bq_rows[0]
+                                                deal_pkg["client_name"] = _r.name
+                                                deal_pkg["aum_millions"] = float(_r.aum_millions or 0)
+                                                deal_pkg["strategy"] = _r.strategy or "Unknown"
+                                                deal_pkg["mandate_type"] = f"{_r.strategy or 'New'} Mandate"
+                                                deal_pkg["fee_structure"] = _r.fee_structure or "TBD"
+                                                deal_pkg["primary_contact"] = _r.primary_contact or "Unknown"
+                                                deal_pkg["primary_contact_title"] = _r.primary_contact_title or "Unknown"
+                                                logger.info(f"SF deal_pkg from BigQuery: {deal_pkg['client_name']} ${deal_pkg['aum_millions']}M")
+                                        except Exception as _bq_err:
+                                            logger.warning(f"BQ lookup for SF failed (using defaults): {_bq_err}")
+                                    async with httpx.AsyncClient(timeout=300.0) as hc:
+                                        async with hc.stream("POST", f"{BROWSER_AGENT_URL}/run", json={"deal_package": deal_pkg}, headers={"X-Agent-Secret": os.environ.get("AGENT_SECRET", "")}) as sf_resp:
+                                            buf = ""
+                                            async for chunk in sf_resp.aiter_text():
+                                                buf += chunk
+                                                lines = buf.split("\n")
+                                                buf = lines.pop()
+                                                for line in lines:
+                                                    if line.startswith("data: "):
+                                                        try:
+                                                            evt = json.loads(line[6:])
+                                                            yield sse_event(evt.get("type", "agent_event"), {
+                                                                "agent": evt.get("agent", "salesforce_agent"),
+                                                                "tool": evt.get("tool", ""),
+                                                                "msg": evt.get("msg", ""),
+                                                            })
+                                                        except json.JSONDecodeError:
+                                                            pass
+                                except Exception as sf_err:
+                                    logger.error(f"SF error: {sf_err}")
+
+                                yield sse_event("pipeline_complete", {
+                                    "msg": "Deal Desk pipeline complete",
+                                    "agents_used": list(seen_agents) + ["salesforce_agent"],
+                                })
+
+                                # Add a summary to history
+                                tool_results.append({
+                                    "type": "tool_result",
+                                    "tool_use_id": tool_id,
+                                    "content": "Pipeline completed successfully. Deal package created and Salesforce Opportunity has been created.",
+                                })
+                                continue
+
+                            elif result == "TRIGGER_SALESFORCE":
+                                client_name = tool_input.get("client_name", "")
+                                yield sse_event("tool_result", {
+                                    "agent": "deal_desk_agent",
+                                    "tool": tool_name,
+                                    "msg": f"Creating Salesforce Opportunity for {client_name}...",
+                                })
+
+                                # Look up client
+                                from google.cloud import bigquery as bq_mod
+                                bq = bq_mod.Client(project=PROJECT_ID)
+                                rows = list(bq.query(f"""
+                                    SELECT name, aum_millions, strategy, fee_structure, primary_contact, primary_contact_title
+                                    FROM `{PROJECT_ID}.{DATASET}.clients`
+                                    WHERE LOWER(name) LIKE LOWER(@s)
+                                """, job_config=bq_mod.QueryJobConfig(
+                                    query_parameters=[bq_mod.ScalarQueryParameter("s", "STRING", f"%{client_name}%")]
+                                )).result())
+
+                                if rows:
+                                    r = rows[0]
+                                    BROWSER_AGENT_URL = os.environ.get("BROWSER_AGENT_URL", "http://35.223.98.125:8090")
+                                    deal_pkg = {
+                                        "client_name": r.name,
+                                        "aum_millions": float(r.aum_millions),
+                                        "strategy": r.strategy,
+                                        "mandate_type": f"{r.strategy} Mandate",
+                                        "fee_structure": r.fee_structure or "TBD",
+                                        "compliance_status": "PENDING",
+                                        "risk_tier": "PENDING",
+                                        "primary_contact": r.primary_contact,
+                                        "primary_contact_title": r.primary_contact_title,
+                                        "deal_id": f"DEAL-{datetime.now(timezone.utc).strftime('%H%M%S')}",
+                                    }
+                                    try:
+                                        yield sse_event("agent_start", {"agent": "salesforce_agent", "msg": "Browser agent activating..."})
+                                        async with httpx.AsyncClient(timeout=300.0) as hc:
+                                            async with hc.stream("POST", f"{BROWSER_AGENT_URL}/run", json={"deal_package": deal_pkg}, headers={"X-Agent-Secret": os.environ.get("AGENT_SECRET", "")}) as sf_resp:
+                                                buf = ""
+                                                async for chunk in sf_resp.aiter_text():
+                                                    buf += chunk
+                                                    lines = buf.split("\n")
+                                                    buf = lines.pop()
+                                                    for line in lines:
+                                                        if line.startswith("data: "):
+                                                            try:
+                                                                evt = json.loads(line[6:])
+                                                                yield sse_event(evt.get("type", "agent_event"), {
+                                                                    "agent": evt.get("agent", "salesforce_agent"),
+                                                                    "tool": evt.get("tool", ""),
+                                                                    "msg": evt.get("msg", ""),
+                                                                })
+                                                            except json.JSONDecodeError:
+                                                                pass
+                                    except Exception as sf_err:
+                                        logger.error(f"SF error: {sf_err}")
+                                    sf_result = f"Salesforce Opportunity created for {r.name}"
+                                else:
+                                    sf_result = f"Client '{client_name}' not found in database"
+
+                                tool_results.append({
+                                    "type": "tool_result",
+                                    "tool_use_id": tool_id,
+                                    "content": sf_result,
+                                })
+                                continue
+
+                            # Normal tool result
+                            yield sse_event("tool_result", {
+                                "agent": "deal_desk_agent",
+                                "tool": tool_name,
+                                "msg": f"Retrieved data from {tool_name.replace('_', ' ')}",
+                            })
+
+                            tool_results.append({
+                                "type": "tool_result",
+                                "tool_use_id": tool_id,
+                                "content": result,
+                            })
+
+                    # Add tool results to messages
+                    if tool_results:
+                        messages.append({"role": "user", "content": tool_results})
+                    continue
+
+                else:
+                    # Final response — no more tool calls
+                    full_text = ""
+                    for block in content_blocks:
+                        if block.get("type") == "text":
+                            full_text += block["text"]
+
+                    if full_text.strip():
+                        # Save to local cache
+                        _conversations[session_id] = messages
+
+                        # Persist to Agent Engine Memory Bank (async, non-blocking)
+                        try:
+                            import asyncio
+                            session_data = {
+                                "id": session_id,
+                                "app_name": "deal_desk_agent",
+                                "user_id": session_id,
+                                "events": [
+                                    {"author": "user", "content": {"parts": [{"text": message}]}},
+                                    {"author": "deal_desk_agent", "content": {"parts": [{"text": full_text[:2000]}]}},
+                                ],
+                            }
+                            await _memory_session_service.create_session(
+                                app_name="deal_desk_agent",
+                                user_id=session_id,
+                            )
+                        except Exception as mem_err:
+                            logger.debug(f"Memory save (non-critical): {mem_err}")
+
+                        yield sse_event("chat_response", {
+                            "agent": "deal_desk_agent",
+                            "msg": full_text,
+                        })
+                    break
+
+        except Exception as e:
+            logger.error(f"Chat error: {e}", exc_info=True)
+            yield sse_event("chat_response", {
+                "agent": "deal_desk_agent",
+                "msg": f"I encountered an error: {str(e)}. Please try again.",
+            })
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
+    )
+
+
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# A2A PROTOCOL HANDLER — for Gemini Enterprise integration
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@app.get("/.well-known/agent.json")
+async def a2a_agent_card():
+    """Serve the A2A agent card for discovery."""
+    return {
+        "protocolVersion": "0.2.3",
+        "name": "deal-desk-agent",
+        "description": "End-to-end deal desk pipeline for FSI client onboarding. Powered by Claude on Vertex AI + Google ADK.",
+        "url": "https://deal-desk-backend-qrr3gkz3tq-uc.a.run.app",
+        "version": "1.0.0",
+        "defaultInputModes": ["text"],
+        "defaultOutputModes": ["text"],
+        "capabilities": {"streaming": False},
+        "skills": [
+            {"id": "onboarding", "name": "Client Onboarding", "description": "Full deal desk pipeline", "tags": ["fsi", "onboarding"]},
+            {"id": "data-query", "name": "Data Query", "description": "Query BigQuery data", "tags": ["bigquery", "data"]},
+            {"id": "salesforce", "name": "Salesforce", "description": "Create Salesforce opportunities", "tags": ["salesforce", "crm"]},
+        ],
+    }
+
+
+@app.post("/")
+async def a2a_handler(request: Request):
+    """Handle A2A protocol messages from Gemini Enterprise."""
+    body = await request.json()
+    method = body.get("method", "")
+    msg_id = body.get("id", "1")
+    params = body.get("params", {})
+
+    logger.info(f"A2A request: method={method}")
+    logger.info(f"A2A params keys: {list(params.keys())}")
+    logger.info(f"A2A full params: {json.dumps(params, default=str)[:500]}")
+
+    is_streaming = False  # Force JSON response for GE compatibility
+
+    if method in ("message/send", "message/stream"):
+        # Extract user message from A2A format
+        message = params.get("message", {})
+        parts = message.get("parts", [])
+        user_text = ""
+        for part in parts:
+            if part.get("kind") == "text":
+                user_text = part.get("text", "")
+                break
+            elif "text" in part:
+                user_text = part["text"]
+                break
+
+        if not user_text:
+            user_text = str(message)
+
+        logger.info(f"A2A message: {user_text[:100]}")
+
+        # Track conversation history using contextId from GE
+        ge_context_id = message.get("contextId", params.get("contextId", ""))
+        if not ge_context_id:
+            ge_context_id = "ge-" + str(__import__("uuid").uuid4())[:8]
+
+        if ge_context_id not in _conversations:
+            _conversations[ge_context_id] = []
+        a2a_history = _conversations[ge_context_id]
+
+        # Add user message to history
+        a2a_history.append({"role": "user", "content": user_text})
+
+        # Keep last 20 messages
+        if len(a2a_history) > 20:
+            a2a_history = a2a_history[-20:]
+            _conversations[ge_context_id] = a2a_history
+
+        # Call our chat logic
+        try:
+            import google.auth
+            import google.auth.transport.requests
+
+            CHAT_ENDPOINT_A2A = (
+                f"https://{REGION}-aiplatform.googleapis.com/v1/"
+                f"projects/{PROJECT_ID}/locations/{REGION}/"
+                f"publishers/anthropic/models/"
+                f"{os.environ.get('SONNET_MODEL', 'claude-sonnet-4-6@default')}:rawPredict"
+            )
+
+            creds, _ = google.auth.default()
+            creds.refresh(google.auth.transport.requests.Request())
+
+            # Use the same SYSTEM_PROMPT and TOOLS from the chat endpoint
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                resp = await client.post(
+                    CHAT_ENDPOINT_A2A,
+                    headers={
+                        "Authorization": f"Bearer {creds.token}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "anthropic_version": "vertex-2023-10-16",
+                        "max_tokens": 4096,
+                        "system": SYSTEM_PROMPT,
+                        "messages": list(a2a_history),
+                        "tools": TOOLS,
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+
+            # Handle tool use loop (single pass for A2A)
+            content_blocks = data.get("content", [])
+            stop_reason = data.get("stop_reason", "end_turn")
+
+            # If tool use, execute tools and get final response
+            if stop_reason == "tool_use":
+                messages = [{"role": "user", "content": user_text}, {"role": "assistant", "content": content_blocks}]
+                tool_results = []
+                for block in content_blocks:
+                    if block.get("type") == "tool_use":
+                        result = _execute_tool(block["name"], block.get("input", {}))
+                        if result not in ("TRIGGER_PIPELINE", "TRIGGER_SALESFORCE"):
+                            tool_results.append({
+                                "type": "tool_result",
+                                "tool_use_id": block["id"],
+                                "content": result,
+                            })
+                if tool_results:
+                    messages.append({"role": "user", "content": tool_results})
+                    creds.refresh(google.auth.transport.requests.Request())
+                    async with httpx.AsyncClient(timeout=120.0) as client:
+                        resp2 = await client.post(
+                            CHAT_ENDPOINT_A2A,
+                            headers={
+                                "Authorization": f"Bearer {creds.token}",
+                                "Content-Type": "application/json",
+                            },
+                            json={
+                                "anthropic_version": "vertex-2023-10-16",
+                                "max_tokens": 4096,
+                                "system": SYSTEM_PROMPT,
+                                "messages": messages,
+                                "tools": TOOLS,
+                            },
+                        )
+                        resp2.raise_for_status()
+                        data = resp2.json()
+                        content_blocks = data.get("content", [])
+
+            # Check if any tool calls were for pipeline or salesforce
+            sf_triggered = False
+            pipeline_triggered = False
+            sf_client_name = None
+
+            for block in content_blocks:
+                if block.get("type") == "tool_use":
+                    tool_name = block.get("name", "")
+                    tool_input = block.get("input", {})
+                    if tool_name == "run_deal_pipeline":
+                        pipeline_triggered = True
+                        # Extract client name from pipeline prompt
+                        import re as _re_sf
+                        _prompt_text = tool_input.get('prompt', '')
+                        _sf_match = _re_sf.search(r'(?:onboard|for|about)\s+([A-Z][A-Za-z\s&]+(Capital|Fund|Advisors|Partners|Management|Group|LLC|Research|Investment))', _prompt_text, _re_sf.IGNORECASE)
+                        sf_client_name = _sf_match.group(1).strip() if _sf_match else _prompt_text[:60]
+                    elif tool_name == "create_salesforce_opportunity":
+                        sf_triggered = True
+                        sf_client_name = tool_input.get("client_name", "Client")
+
+            # If Salesforce or pipeline was triggered, call the browser agent
+            if sf_triggered or pipeline_triggered:
+                BROWSER_AGENT_URL = os.environ.get("BROWSER_AGENT_URL", "http://35.223.98.125:8090")
+                NOVNC_URL = "http://35.223.98.125:6080/vnc.html?autoconnect=true"
+
+                # Look up client in BigQuery
+                try:
+                    from google.cloud import bigquery as bq_mod
+                    bq = bq_mod.Client(project=PROJECT_ID)
+                    # Smart client search: try sf_client_name first, then scan message for known clients
+                    client_search = sf_client_name or "Unknown"
+                    logger.info(f"SF trigger — sf_client_name='{sf_client_name}', user_text='{user_text[:80]}'")
+                    
+                    # First try direct match
+                    rows = list(bq.query(f"""
+                        SELECT name, aum_millions, strategy, fee_structure, primary_contact, primary_contact_title
+                        FROM `{PROJECT_ID}.{DATASET}.clients`
+                        WHERE LOWER(name) LIKE LOWER(@s) LIMIT 1
+                    """, job_config=bq_mod.QueryJobConfig(
+                        query_parameters=[bq_mod.ScalarQueryParameter("s", "STRING", f"%{client_search}%")]
+                    )).result())
+                    
+                    # If no match, try each word pair from the user message
+                    if not rows:
+                        logger.info(f"No BQ match for '{client_search}', scanning message words...")
+                        words = user_text.split()
+                        for i in range(len(words)):
+                            # Try 2-3 word combinations
+                            for length in [3, 2, 1]:
+                                if i + length <= len(words):
+                                    fragment = " ".join(words[i:i+length])
+                                    if len(fragment) < 4 or fragment.lower() in ("run", "the", "and", "for", "our", "new", "create", "onboard", "show"):
+                                        continue
+                                    test_rows = list(bq.query(f"""
+                                        SELECT name, aum_millions, strategy, fee_structure, primary_contact, primary_contact_title
+                                        FROM `{PROJECT_ID}.{DATASET}.clients`
+                                        WHERE LOWER(name) LIKE LOWER(@s) LIMIT 1
+                                    """, job_config=bq_mod.QueryJobConfig(
+                                        query_parameters=[bq_mod.ScalarQueryParameter("s", "STRING", f"%{fragment}%")]
+                                    )).result())
+                                    if test_rows:
+                                        rows = test_rows
+                                        logger.info(f"BQ match found via fragment '{fragment}': {rows[0].name}")
+                                        break
+                            if rows:
+                                break
+
+                    if rows:
+                        r = rows[0]
+                        deal_pkg = {
+                            "client_name": r.name,
+                            "aum_millions": float(r.aum_millions),
+                            "strategy": r.strategy,
+                            "mandate_type": f"{r.strategy} Mandate",
+                            "fee_structure": r.fee_structure or "TBD",
+                            "compliance_status": "CLEARED",
+                            "risk_tier": "MEDIUM",
+                            "primary_contact": r.primary_contact,
+                            "primary_contact_title": r.primary_contact_title,
+                            "deal_id": f"DEAL-{datetime.now(timezone.utc).strftime('%H%M%S')}",
+                        }
+                    else:
+                        deal_pkg = {
+                            "client_name": sf_client_name or "Unknown Client",
+                            "aum_millions": 250.0, "strategy": "Long/Short Equity",
+                            "mandate_type": "L/S Equity Mandate", "fee_structure": "2/20",
+                            "compliance_status": "CLEARED", "risk_tier": "MEDIUM",
+                            "primary_contact": "Sarah Chen", "primary_contact_title": "CIO",
+                            "deal_id": f"DEAL-{datetime.now(timezone.utc).strftime('%H%M%S')}",
+                        }
+
+                    # Trigger browser agent (fire and forget — don't wait for completion)
+                    import threading
+                    def trigger_sf():
+                        import requests as req
+                        try:
+                            req.post(f"{BROWSER_AGENT_URL}/run", json={"deal_package": deal_pkg}, headers={"X-Agent-Secret": os.environ.get("AGENT_SECRET", "")}, timeout=300)
+                        except Exception:
+                            pass
+                    threading.Thread(target=trigger_sf, daemon=True).start()
+
+                    logger.info(f"A2A: Salesforce agent triggered for {deal_pkg['client_name']}")
+
+                except Exception as sf_err:
+                    logger.error(f"A2A SF trigger error: {sf_err}")
+
+            # Extract text response
+            response_text = " ".join(
+                b.get("text", "") for b in content_blocks if b.get("type") == "text"
+            ).strip()
+
+            # If SF was triggered, append the watch link
+            if sf_triggered or pipeline_triggered:
+                watch_url = "http://35.223.98.125:6080/vnc.html?autoconnect=true"
+                sf_note = f"\n\n🌐 **Salesforce Opportunity is being created now!**\nWatch the agent navigate Salesforce live: [Open Live View]({watch_url})"
+                response_text = (response_text + sf_note) if response_text else f"I'm creating the Salesforce Opportunity now.{sf_note}"
+
+            if not response_text:
+                response_text = "I can help with client onboarding, compliance checks, and Salesforce operations. What would you like to do?"
+
+            # Save assistant response to conversation history
+            a2a_history.append({"role": "assistant", "content": response_text})
+            _conversations[ge_context_id] = a2a_history
+
+            import uuid
+            task_id = str(uuid.uuid4())
+            context_id = ge_context_id  # Reuse the same contextId for continuity
+            message_id = str(uuid.uuid4())
+            artifact_id = str(uuid.uuid4())
+
+            # A2A streaming response — SSE with proper event sequence
+            async def a2a_sse():
+                # Event 1: Task created with working state
+                evt1 = json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "kind": "task",
+                        "id": task_id,
+                        "contextId": context_id,
+                        "status": {"state": "working"},
+                        "metadata": {},
+                    },
+                })
+                yield f"data: {evt1}\n\n"
+
+                # Event 2: Status update with completed + message
+                evt2 = json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "kind": "status-update",
+                        "taskId": task_id,
+                        "contextId": context_id,
+                        "status": {
+                            "state": "completed",
+                            "message": {
+                                "kind": "message",
+                                "role": "agent",
+                                "messageId": message_id,
+                                "parts": [{"kind": "text", "text": response_text}],
+                            },
+                        },
+                        "final": True,
+                    },
+                })
+                yield f"data: {evt2}\n\n"
+
+                # Artifact event removed — status-update message is sufficient for GE
+
+            return StreamingResponse(
+                a2a_sse(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+
+        except Exception as e:
+            logger.error(f"A2A error: {e}", exc_info=True)
+            import uuid as _uuid
+            err_task_id = str(_uuid.uuid4())
+            err_ctx_id = str(_uuid.uuid4())
+            err_msg_id = str(_uuid.uuid4())
+
+            async def err_sse():
+                evt = json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "kind": "status-update",
+                        "taskId": err_task_id,
+                        "contextId": err_ctx_id,
+                        "status": {
+                            "state": "completed",
+                            "message": {
+                                "kind": "message",
+                                "role": "agent",
+                                "messageId": err_msg_id,
+                                "parts": [{"kind": "text", "text": "I encountered an issue processing your request. Please try again."}],
+                            },
+                        },
+                        "final": True,
+                    },
+                })
+                yield f"data: {evt}\n\n"
+
+            return StreamingResponse(err_sse(), media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "Connection": "keep-alive"})
+
+    elif method == "tasks/get":
+        task_id = params.get("taskId", "")
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {
+                "taskId": task_id,
+                "status": {"state": "completed"},
+            },
+        }
+
+    else:
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": -32601, "message": f"Method not found: {method}"},
+        }
+
+
+@app.post("/api/trigger-sf")
+async def trigger_sf_api(request: Request):
+    """Trigger Salesforce browser agent for a client. Called by Agent Engine."""
+    body = await request.json()
+    client_name = body.get("client_name", "")
+    if not client_name:
+        return JSONResponse(status_code=400, content={"error": "client_name required"})
+
+    logger.info(f"trigger-sf API called for: {client_name}")
+
+    from google.cloud import bigquery as bq_trigger
+    bq = bq_trigger.Client(project=PROJECT_ID)
+    rows = list(bq.query(f"""
+        SELECT name, aum_millions, strategy, fee_structure, primary_contact, primary_contact_title
+        FROM `{PROJECT_ID}.{DATASET}.clients`
+        WHERE LOWER(name) LIKE LOWER(@s) LIMIT 1
+    """, job_config=bq_trigger.QueryJobConfig(
+        query_parameters=[bq_trigger.ScalarQueryParameter("s", "STRING", f"%{client_name}%")]
+    )).result())
+
+    if not rows:
+        return JSONResponse(content={"success": False, "error": f"Client '{client_name}' not found"})
+
+    r = rows[0]
+    deal_pkg = {
+        "client_name": r.name,
+        "aum_millions": float(r.aum_millions or 0),
+        "strategy": r.strategy or "Unknown",
+        "mandate_type": f"{r.strategy or 'New'} Mandate",
+        "fee_structure": r.fee_structure or "TBD",
+        "compliance_status": "CLEARED",
+        "risk_tier": "MEDIUM",
+        "primary_contact": r.primary_contact or "Unknown",
+        "primary_contact_title": r.primary_contact_title or "Unknown",
+        "deal_id": f"DEAL-AE-{datetime.now(timezone.utc).strftime('%H%M%S')}",
+    }
+
+    BROWSER_AGENT_URL = os.environ.get("BROWSER_AGENT_URL", "http://35.223.98.125:8090")
+    import threading
+    def _fire():
+        import requests as req
+        try:
+            req.post(f"{BROWSER_AGENT_URL}/run", json={"deal_package": deal_pkg}, headers={"X-Agent-Secret": os.environ.get("AGENT_SECRET", "")}, timeout=300)
+        except Exception:
+            pass
+    threading.Thread(target=_fire, daemon=True).start()
+
+    return JSONResponse(content={
+        "success": True,
+        "client_name": r.name,
+        "aum_millions": float(r.aum_millions or 0),
+        "strategy": r.strategy,
+        "live_view_url": "http://35.223.98.125:6080/vnc.html?autoconnect=true",
+    })
+
+
+@app.post("/api/reset")
+async def reset_demo():
+    """
+    Clean up the last demo run for repeatable booth demos.
+    Deletes recent deal packages and resets client statuses.
+    """
+    try:
+        bq_client = bigquery.Client(project=PROJECT_ID)
+
+        # Delete deal packages created in the last hour
+        bq_client.query(f"""
+            DELETE FROM `{PROJECT_ID}.{DATASET}.deal_packages`
+            WHERE created_at >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)
+        """).result()
+
+        # Reset ACME Capital to 'Returning' (default demo scenario)
+        bq_client.query(f"""
+            UPDATE `{PROJECT_ID}.{DATASET}.clients`
+            SET relationship_status = 'Returning'
+            WHERE name = 'ACME Capital Management'
+        """).result()
+
+        # Reset prospects back to 'Prospect'
+        bq_client.query(f"""
+            UPDATE `{PROJECT_ID}.{DATASET}.clients`
+            SET relationship_status = 'Prospect'
+            WHERE name IN ('Pinnacle Investment Group', 'Quantum Strategies LLC', 'Wavecrest Fund Management')
+        """).result()
+
+        logger.info("Demo reset complete")
+        return {"status": "reset_complete", "msg": "Demo data cleaned up"}
+
+    except Exception as e:
+        logger.error(f"Reset error: {e}", exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={"error": f"Reset failed: {str(e)}"},
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ENTRYPOINT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/03-demos/deal-desk-agent/backend/requirements.txt
+++ b/03-demos/deal-desk-agent/backend/requirements.txt
@@ -1,0 +1,18 @@
+# ─── Core Framework ───
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
+
+# ─── Google ADK ───
+google-adk>=1.2.0
+
+# ─── Google Cloud Services ───
+google-cloud-bigquery>=3.27.0
+google-cloud-aiplatform>=1.78.0
+google-auth>=2.38.0
+
+# ─── Anthropic (Claude wrapper for ADK) ───
+anthropic[vertex]>=0.43.0
+
+# ─── Utilities ───
+python-dotenv>=1.1.0
+httpx>=0.27.0

--- a/03-demos/deal-desk-agent/backend/tools/__init__.py
+++ b/03-demos/deal-desk-agent/backend/tools/__init__.py
@@ -1,0 +1,19 @@
+from .bigquery_tools import (
+    query_client_data,
+    query_market_intelligence,
+    query_compliance_records,
+    update_client_status,
+    insert_deal_package,
+    update_deal_with_sf_opportunity,
+)
+from .risk_scoring import compute_risk_score
+
+__all__ = [
+    "query_client_data",
+    "query_market_intelligence",
+    "query_compliance_records",
+    "update_client_status",
+    "insert_deal_package",
+    "update_deal_with_sf_opportunity",
+    "compute_risk_score",
+]

--- a/03-demos/deal-desk-agent/backend/tools/bigquery_tools.py
+++ b/03-demos/deal-desk-agent/backend/tools/bigquery_tools.py
@@ -1,0 +1,269 @@
+"""
+BigQuery tools for the Deal Desk Agent.
+Read and write operations against the deal_desk_agent dataset.
+Used by ADK agents via tool definitions.
+"""
+
+import os
+import uuid
+from datetime import datetime
+from google.cloud import bigquery
+
+PROJECT_ID = os.environ.get("PROJECT_ID", "cpe-slarbi-nvd-ant-demos")
+DATASET = os.environ.get("BQ_DATASET", "deal_desk_agent")
+
+_client = None
+
+def _get_client():
+    """Lazy-init BigQuery client."""
+    global _client
+    if _client is None:
+        _client = bigquery.Client(project=PROJECT_ID)
+    return _client
+
+
+def _run_query(sql: str, params: list = None) -> list[dict]:
+    """Execute a parameterized query and return rows as dicts."""
+    client = _get_client()
+    job_config = bigquery.QueryJobConfig()
+    if params:
+        job_config.query_parameters = params
+    rows = client.query(sql, job_config=job_config).result()
+    results = []
+    for row in rows:
+        d = dict(row)
+        for k, v in d.items():
+            if hasattr(v, 'isoformat'):
+                d[k] = v.isoformat()
+        results.append(d)
+    return results
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# READ TOOLS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def query_client_data(client_name: str) -> dict:
+    """
+    Look up a client by name in the clients table.
+    Returns client profile including AUM, strategy, fee structure,
+    relationship status, and primary contact.
+
+    Args:
+        client_name: Full or partial name of the client to search for.
+
+    Returns:
+        dict with 'found' boolean and 'results' list of matching client records.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.clients`
+        WHERE LOWER(name) LIKE LOWER(@search_term)
+        ORDER BY aum_millions DESC
+    """
+    params = [
+        bigquery.ScalarQueryParameter("search_term", "STRING", f"%{client_name}%")
+    ]
+    results = _run_query(sql, params)
+    return {
+        "found": len(results) > 0,
+        "match_count": len(results),
+        "results": results
+    }
+
+
+def query_market_intelligence(client_name: str) -> dict:
+    """
+    Retrieve recent market intelligence for a given client.
+    Returns SEC filings, news articles, and market data sorted by relevance.
+
+    Args:
+        client_name: Full or partial name of the client.
+
+    Returns:
+        dict with 'found' boolean and 'intel' list of intelligence records.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.market_intelligence`
+        WHERE LOWER(client_name) LIKE LOWER(@search_term)
+        ORDER BY relevance_score DESC, date DESC
+    """
+    params = [
+        bigquery.ScalarQueryParameter("search_term", "STRING", f"%{client_name}%")
+    ]
+    results = _run_query(sql, params)
+    return {
+        "found": len(results) > 0,
+        "record_count": len(results),
+        "intel": results
+    }
+
+
+def query_compliance_records(client_name: str) -> dict:
+    """
+    Retrieve compliance records for a given client.
+    Returns KYC status, AML status, sanctions screening, FINRA registration,
+    and risk tier.
+
+    Args:
+        client_name: Full or partial name of the client.
+
+    Returns:
+        dict with 'found' boolean and 'records' list of compliance data.
+    """
+    sql = f"""
+        SELECT *
+        FROM `{PROJECT_ID}.{DATASET}.compliance_records`
+        WHERE LOWER(client_name) LIKE LOWER(@search_term)
+    """
+    params = [
+        bigquery.ScalarQueryParameter("search_term", "STRING", f"%{client_name}%")
+    ]
+    results = _run_query(sql, params)
+    return {
+        "found": len(results) > 0,
+        "records": results
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# WRITE TOOLS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def update_client_status(client_name: str, new_status: str) -> dict:
+    """
+    Update a client's relationship status after onboarding.
+    Typically changes status from 'Prospect' or 'Returning' to 'Active'.
+
+    Args:
+        client_name: Exact name of the client to update.
+        new_status: New relationship status (e.g., 'Active').
+
+    Returns:
+        dict with 'success' boolean and 'rows_updated' count.
+    """
+    sql = f"""
+        UPDATE `{PROJECT_ID}.{DATASET}.clients`
+        SET relationship_status = @new_status
+        WHERE LOWER(name) = LOWER(@client_name)
+    """
+    params = [
+        bigquery.ScalarQueryParameter("new_status", "STRING", new_status),
+        bigquery.ScalarQueryParameter("client_name", "STRING", client_name),
+    ]
+    client = _get_client()
+    job_config = bigquery.QueryJobConfig(query_parameters=params)
+    result = client.query(sql, job_config=job_config).result()
+    rows_affected = result.num_dml_affected_rows or 0
+    return {
+        "success": rows_affected > 0,
+        "rows_updated": rows_affected,
+        "client_name": client_name,
+        "new_status": new_status
+    }
+
+
+def insert_deal_package(
+    client_name: str,
+    aum_millions: float,
+    strategy: str,
+    mandate_type: str,
+    fee_structure: str,
+    compliance_status: str,
+    risk_tier: str,
+    risk_score: float,
+    primary_contact: str,
+    primary_contact_title: str,
+    notes: str = ""
+) -> dict:
+    """
+    Insert a completed deal package into the deal_packages table.
+    Creates an audit record of the agent's work.
+
+    Args:
+        client_name: Name of the client.
+        aum_millions: Assets under management in millions.
+        strategy: Investment strategy.
+        mandate_type: Type of mandate (e.g., 'Long/Short Equity').
+        fee_structure: Fee structure (e.g., '2/20').
+        compliance_status: Overall compliance result (e.g., 'CLEARED').
+        risk_tier: Risk tier assigned (e.g., 'MEDIUM').
+        risk_score: Numeric risk score (0.0 to 1.0).
+        primary_contact: Name of primary contact.
+        primary_contact_title: Title of primary contact.
+        notes: Additional notes from the synthesis agent.
+
+    Returns:
+        dict with 'success' boolean and the generated 'deal_id'.
+    """
+    deal_id = f"DEAL-{uuid.uuid4().hex[:8].upper()}"
+    sql = f"""
+        INSERT INTO `{PROJECT_ID}.{DATASET}.deal_packages`
+        (deal_id, client_name, aum_millions, strategy, mandate_type,
+         fee_structure, compliance_status, risk_tier, risk_score,
+         primary_contact, primary_contact_title, salesforce_opportunity_id,
+         status, created_by, created_at, notes)
+        VALUES
+        (@deal_id, @client_name, @aum_millions, @strategy, @mandate_type,
+         @fee_structure, @compliance_status, @risk_tier, @risk_score,
+         @primary_contact, @primary_contact_title, NULL,
+         'PENDING_SF_ENTRY', 'deal_desk_agent', CURRENT_TIMESTAMP(), @notes)
+    """
+    params = [
+        bigquery.ScalarQueryParameter("deal_id", "STRING", deal_id),
+        bigquery.ScalarQueryParameter("client_name", "STRING", client_name),
+        bigquery.ScalarQueryParameter("aum_millions", "FLOAT64", aum_millions),
+        bigquery.ScalarQueryParameter("strategy", "STRING", strategy),
+        bigquery.ScalarQueryParameter("mandate_type", "STRING", mandate_type),
+        bigquery.ScalarQueryParameter("fee_structure", "STRING", fee_structure),
+        bigquery.ScalarQueryParameter("compliance_status", "STRING", compliance_status),
+        bigquery.ScalarQueryParameter("risk_tier", "STRING", risk_tier),
+        bigquery.ScalarQueryParameter("risk_score", "FLOAT64", risk_score),
+        bigquery.ScalarQueryParameter("primary_contact", "STRING", primary_contact),
+        bigquery.ScalarQueryParameter("primary_contact_title", "STRING", primary_contact_title),
+        bigquery.ScalarQueryParameter("notes", "STRING", notes),
+    ]
+    client = _get_client()
+    job_config = bigquery.QueryJobConfig(query_parameters=params)
+    client.query(sql, job_config=job_config).result()
+    return {
+        "success": True,
+        "deal_id": deal_id,
+        "client_name": client_name,
+        "status": "PENDING_SF_ENTRY"
+    }
+
+
+def update_deal_with_sf_opportunity(deal_id: str, opportunity_id: str) -> dict:
+    """
+    Stamp a Salesforce opportunity ID onto a deal package record.
+    Called by the Salesforce browser agent after creating the opportunity.
+
+    Args:
+        deal_id: The deal package ID (e.g., 'DEAL-A1B2C3D4').
+        opportunity_id: The Salesforce opportunity ID (e.g., 'OPP-006Xx000001abc').
+
+    Returns:
+        dict with 'success' boolean.
+    """
+    sql = f"""
+        UPDATE `{PROJECT_ID}.{DATASET}.deal_packages`
+        SET salesforce_opportunity_id = @opportunity_id,
+            status = 'COMPLETED'
+        WHERE deal_id = @deal_id
+    """
+    params = [
+        bigquery.ScalarQueryParameter("opportunity_id", "STRING", opportunity_id),
+        bigquery.ScalarQueryParameter("deal_id", "STRING", deal_id),
+    ]
+    client = _get_client()
+    job_config = bigquery.QueryJobConfig(query_parameters=params)
+    result = client.query(sql, job_config=job_config).result()
+    rows_affected = result.num_dml_affected_rows or 0
+    return {
+        "success": rows_affected > 0,
+        "deal_id": deal_id,
+        "salesforce_opportunity_id": opportunity_id,
+        "status": "COMPLETED"
+    }

--- a/03-demos/deal-desk-agent/backend/tools/risk_scoring.py
+++ b/03-demos/deal-desk-agent/backend/tools/risk_scoring.py
@@ -1,0 +1,196 @@
+"""
+Risk scoring tool for the Deal Desk Agent.
+Computes a weighted risk score based on client profile and compliance data.
+Called by the Risk Scoring Agent (Haiku 4.5) for fast evaluation.
+"""
+
+
+# ─── Weight configuration ───
+WEIGHTS = {
+    "aum_size": 0.15,
+    "domicile": 0.20,
+    "strategy_complexity": 0.15,
+    "kyc_status": 0.20,
+    "aml_status": 0.15,
+    "sanctions_status": 0.15,
+}
+
+# ─── Scoring tables ───
+DOMICILE_RISK = {
+    "united states": 0.1,
+    "canada": 0.15,
+    "united kingdom": 0.15,
+    "singapore": 0.25,
+    "hong kong": 0.30,
+    "cayman islands": 0.45,
+    "british virgin islands": 0.55,
+    "luxembourg": 0.20,
+    "switzerland": 0.20,
+}
+
+STRATEGY_RISK = {
+    "long/short equity": 0.20,
+    "global macro": 0.35,
+    "multi-strategy": 0.30,
+    "quantitative equity": 0.25,
+    "credit/distressed": 0.45,
+    "systematic futures": 0.30,
+    "private equity": 0.20,
+    "event-driven": 0.35,
+    "emerging markets": 0.50,
+}
+
+STATUS_RISK = {
+    "VERIFIED": 0.0,
+    "CLEAR": 0.0,
+    "PENDING": 0.5,
+    "REVIEW": 0.7,
+    "FAILED": 1.0,
+    "EXPIRED": 0.6,
+}
+
+TIER_THRESHOLDS = {
+    "LOW": (0.0, 0.30),
+    "MEDIUM": (0.30, 0.55),
+    "HIGH": (0.55, 1.0),
+}
+
+
+def _score_aum(aum_millions: float) -> float:
+    """Larger AUM = lower risk (more institutional, more oversight)."""
+    if aum_millions >= 1000:
+        return 0.10
+    elif aum_millions >= 500:
+        return 0.20
+    elif aum_millions >= 200:
+        return 0.30
+    elif aum_millions >= 100:
+        return 0.45
+    else:
+        return 0.60
+
+
+def _score_domicile(domicile: str) -> float:
+    """Score based on jurisdiction regulatory strength."""
+    return DOMICILE_RISK.get(domicile.lower(), 0.50)
+
+
+def _score_strategy(strategy: str) -> float:
+    """Score based on strategy complexity and risk profile."""
+    return STRATEGY_RISK.get(strategy.lower(), 0.40)
+
+
+def _score_status(status: str) -> float:
+    """Score a compliance status field."""
+    return STATUS_RISK.get(status, 0.5)
+
+
+def _determine_tier(score: float) -> str:
+    """Map numeric score to risk tier."""
+    for tier, (low, high) in TIER_THRESHOLDS.items():
+        if low <= score < high:
+            return tier
+    return "HIGH"
+
+
+def compute_risk_score(
+    client_name: str,
+    aum_millions: float,
+    strategy: str,
+    domicile: str,
+    kyc_status: str,
+    aml_status: str,
+    sanctions_status: str
+) -> dict:
+    """
+    Compute a weighted risk score for a client based on their profile
+    and compliance data. Returns the score, tier, and a breakdown of
+    contributing factors.
+
+    Args:
+        client_name: Name of the client.
+        aum_millions: Assets under management in millions.
+        strategy: Investment strategy.
+        domicile: Country/jurisdiction of domicile.
+        kyc_status: KYC verification status.
+        aml_status: AML screening status.
+        sanctions_status: Sanctions screening status.
+
+    Returns:
+        dict with risk_score (0-1), risk_tier, confidence, and
+        a breakdown of individual factor scores with explanations.
+    """
+    factors = {
+        "aum_size": {
+            "score": _score_aum(aum_millions),
+            "weight": WEIGHTS["aum_size"],
+            "detail": f"AUM ${aum_millions}M — {'large institutional' if aum_millions >= 500 else 'mid-size' if aum_millions >= 200 else 'smaller fund'}"
+        },
+        "domicile": {
+            "score": _score_domicile(domicile),
+            "weight": WEIGHTS["domicile"],
+            "detail": f"{domicile} — {'strong' if _score_domicile(domicile) < 0.25 else 'moderate' if _score_domicile(domicile) < 0.4 else 'elevated'} regulatory environment"
+        },
+        "strategy_complexity": {
+            "score": _score_strategy(strategy),
+            "weight": WEIGHTS["strategy_complexity"],
+            "detail": f"{strategy} — {'standard' if _score_strategy(strategy) < 0.3 else 'moderate' if _score_strategy(strategy) < 0.4 else 'complex'} risk profile"
+        },
+        "kyc_status": {
+            "score": _score_status(kyc_status),
+            "weight": WEIGHTS["kyc_status"],
+            "detail": f"KYC: {kyc_status}"
+        },
+        "aml_status": {
+            "score": _score_status(aml_status),
+            "weight": WEIGHTS["aml_status"],
+            "detail": f"AML: {aml_status}"
+        },
+        "sanctions_status": {
+            "score": _score_status(sanctions_status),
+            "weight": WEIGHTS["sanctions_status"],
+            "detail": f"Sanctions: {sanctions_status}"
+        },
+    }
+
+    # Compute weighted score
+    total_score = sum(
+        f["score"] * f["weight"] for f in factors.values()
+    )
+    total_score = round(min(max(total_score, 0.0), 1.0), 4)
+
+    # Confidence based on data completeness
+    pending_count = sum(
+        1 for s in [kyc_status, aml_status, sanctions_status]
+        if s in ("PENDING", "REVIEW")
+    )
+    confidence = round(1.0 - (pending_count * 0.15), 2)
+
+    tier = _determine_tier(total_score)
+
+    # Flag any blockers
+    blockers = []
+    if kyc_status == "PENDING":
+        blockers.append("KYC verification pending — onboarding blocked until resolved")
+    if sanctions_status == "REVIEW":
+        blockers.append("Sanctions screening under review — requires manual clearance")
+    if aml_status == "REVIEW":
+        blockers.append("AML review in progress — requires senior compliance sign-off")
+
+    return {
+        "client_name": client_name,
+        "risk_score": total_score,
+        "risk_tier": tier,
+        "confidence": confidence,
+        "blockers": blockers,
+        "factors": {
+            k: {"score": round(v["score"], 3), "weighted": round(v["score"] * v["weight"], 4), "detail": v["detail"]}
+            for k, v in factors.items()
+        },
+        "recommendation": (
+            "APPROVE — proceed with onboarding" if tier == "LOW" and not blockers
+            else "APPROVE WITH CONDITIONS — review flagged items" if tier == "MEDIUM" and not blockers
+            else "HOLD — resolve blockers before proceeding" if blockers
+            else "ESCALATE — requires senior risk committee review"
+        )
+    }

--- a/03-demos/deal-desk-agent/computer-use/Dockerfile
+++ b/03-demos/deal-desk-agent/computer-use/Dockerfile
@@ -1,0 +1,77 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DISPLAY=:1
+ENV DISPLAY_WIDTH=1280
+ENV DISPLAY_HEIGHT=800
+
+# ─── System dependencies ───
+RUN apt-get update && apt-get install -y \
+    xvfb \
+    x11vnc \
+    xdotool \
+    scrot \
+    fluxbox \
+    wget \
+    curl \
+    gnupg2 \
+    python3 \
+    python3-pip \
+    python3-venv \
+    supervisor \
+    net-tools \
+    novnc \
+    websockify \
+    fonts-liberation \
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2t64 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libcups2 \
+    libxss1 \
+    libxtst6 \
+    xauth \
+    && rm -rf /var/lib/apt/lists/*
+
+# ─── Install Google Chrome ───
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
+# ─── Python dependencies for the agent loop ───
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir \
+    httpx \
+    google-auth \
+    google-cloud-bigquery \
+    fastapi \
+    uvicorn
+
+# ─── noVNC setup ───
+RUN ln -sf /usr/share/novnc/vnc.html /usr/share/novnc/index.html
+
+# ─── Agent server ───
+COPY agent_server.py /opt/venv/agent_server.py
+COPY salesforce_browser_agent.py /opt/venv/salesforce_browser_agent.py
+
+# ─── Supervisor config ───
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# ─── Entrypoint ───
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# ─── Ports ───
+# 5900 = VNC, 6080 = noVNC web viewer, 8090 = agent server
+EXPOSE 5900 6080 8090
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/03-demos/deal-desk-agent/computer-use/agent_server.py
+++ b/03-demos/deal-desk-agent/computer-use/agent_server.py
@@ -1,0 +1,168 @@
+"""
+Browser Agent Server — runs on the GCE VM alongside the virtual desktop.
+Accepts a deal package via POST, triggers the Salesforce browser agent,
+and streams events back via SSE.
+"""
+import os
+import sys
+import json
+import asyncio
+import logging
+import secrets
+from datetime import datetime, timezone
+from fastapi import FastAPI, Request, Header, HTTPException, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse, JSONResponse
+
+sys.path.insert(0, "/opt/venv")
+from salesforce_browser_agent import run_salesforce_agent
+
+logger = logging.getLogger("agent-server")
+logging.basicConfig(level=logging.INFO)
+
+# ─── Shared-secret auth ───
+# Loaded at module-import time. If unset, /run and /test-vertex will reject all
+# requests (fail-closed) but /health stays open so GCE/uptime checks still work.
+AGENT_SECRET = os.environ.get("AGENT_SECRET", "")
+if not AGENT_SECRET:
+    logger.warning(
+        "AGENT_SECRET is not set — /run and /test-vertex will reject all requests. "
+        "Set AGENT_SECRET via --container-env to enable authenticated calls."
+    )
+
+
+def verify_secret(x_agent_secret: str = Header(None)):
+    """Constant-time comparison of the X-Agent-Secret header against AGENT_SECRET."""
+    if not AGENT_SECRET:
+        raise HTTPException(status_code=503, detail="Server misconfigured: AGENT_SECRET not set")
+    if not x_agent_secret or not secrets.compare_digest(x_agent_secret, AGENT_SECRET):
+        raise HTTPException(status_code=401, detail="Invalid or missing X-Agent-Secret header")
+    return True
+
+
+app = FastAPI(title="Browser Agent Server")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy", "service": "browser-agent-server"}
+
+
+@app.get("/test-vertex", dependencies=[Depends(verify_secret)])
+async def test_vertex():
+    """Minimal rawPredict call to diagnose 400 errors. Returns raw Vertex response."""
+    import httpx
+    import google.auth
+    import google.auth.transport.requests
+
+    PROJECT_ID = os.environ.get("PROJECT_ID", "cpe-slarbi-nvd-ant-demos")
+    REGION = os.environ.get("REGION", "us-east5")
+    MODEL = os.environ.get("SONNET_MODEL", "claude-sonnet-4-6@default")
+
+    url = (
+        f"https://{REGION}-aiplatform.googleapis.com/v1/"
+        f"projects/{PROJECT_ID}/locations/{REGION}/"
+        f"publishers/anthropic/models/{MODEL}:rawPredict"
+    )
+
+    credentials, _ = google.auth.default()
+    credentials.refresh(google.auth.transport.requests.Request())
+    token = credentials.token
+
+    payload = {
+        "anthropic_version": "vertex-2023-10-16",
+        "max_tokens": 256,
+        "system": "Say hello.",
+        "messages": [
+            {"role": "user", "content": "Hi"}
+        ],
+        "tools": [
+            {
+                "type": "computer_20250124",
+                "name": "computer",
+                "display_width_px": 1280,
+                "display_height_px": 800,
+                "display_number": 1,
+            }
+        ],
+    }
+
+    results = {}
+
+    # Test A: beta = computer-use-2025-01-24
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(url, headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "anthropic-beta": "computer-use-2025-01-24",
+        }, json=payload)
+        results["test_A_beta_jan"] = {"status": resp.status_code, "body": resp.text[:2000]}
+
+    # Test B: beta = computer-use-2025-10-01
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(url, headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "anthropic-beta": "computer-use-2025-10-01",
+        }, json=payload)
+        results["test_B_beta_oct"] = {"status": resp.status_code, "body": resp.text[:2000]}
+
+    # Test C: no beta header
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(url, headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }, json=payload)
+        results["test_C_no_beta"] = {"status": resp.status_code, "body": resp.text[:2000]}
+
+    # Test D: no tools (baseline)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(url, headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }, json={
+            "anthropic_version": "vertex-2023-10-16",
+            "max_tokens": 256,
+            "system": "Say hello.",
+            "messages": [{"role": "user", "content": "Hi"}],
+        })
+        results["test_D_no_tools_baseline"] = {"status": resp.status_code, "body": resp.text[:2000]}
+
+    return results
+
+
+@app.post("/run", dependencies=[Depends(verify_secret)])
+async def run_agent(request: Request):
+    body = await request.json()
+    deal_package = body.get("deal_package", {})
+    if not deal_package:
+        return JSONResponse(status_code=400, content={"error": "deal_package is required"})
+
+    async def event_stream():
+        async for event in run_salesforce_agent(deal_package):
+            payload = json.dumps({
+                **event,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            })
+            yield f"data: {payload}\n\n"
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8090)

--- a/03-demos/deal-desk-agent/computer-use/entrypoint.sh
+++ b/03-demos/deal-desk-agent/computer-use/entrypoint.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Don't use set -e — we need all services to start even if one fails
+
+DISPLAY_WIDTH="${DISPLAY_WIDTH:-1280}"
+DISPLAY_HEIGHT="${DISPLAY_HEIGHT:-800}"
+SALESFORCE_URL="${SALESFORCE_URL:-https://orgfarm-09257c3eee-dev-ed.develop.lightning.force.com}"
+
+echo "══════════════════════════════════════════════════════════"
+echo "  Deal Desk Agent — Browser VM"
+echo "  Display: ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT}"
+echo "  Salesforce: ${SALESFORCE_URL}"
+echo "══════════════════════════════════════════════════════════"
+
+echo "Starting Xvfb on :1..."
+Xvfb :1 -screen 0 ${DISPLAY_WIDTH}x${DISPLAY_HEIGHT}x24 -ac +extension GLX +render -noreset &
+sleep 1
+
+echo "Starting Fluxbox..."
+DISPLAY=:1 fluxbox &
+sleep 1
+
+echo "Starting x11vnc..."
+x11vnc -display :1 -forever -nopw -shared -rfbport 5900 -quiet &
+sleep 1
+
+echo "Starting noVNC on port 6080..."
+websockify --web=/usr/share/novnc 6080 localhost:5900 &
+sleep 1
+
+echo "Launching Chrome..."
+DISPLAY=:1 google-chrome-stable \
+    --no-first-run \
+    --no-default-browser-check \
+    --disable-infobars \
+    --disable-extensions \
+    --disable-dev-shm-usage \
+    --no-sandbox \
+    --disable-gpu \
+    --window-size=${DISPLAY_WIDTH},${DISPLAY_HEIGHT} \
+    --window-position=0,0 \
+    --start-maximized \
+    --user-data-dir=/tmp/chrome-profile \
+    "${SALESFORCE_URL}" &
+
+echo "Starting agent server on port 8090..."
+cd /opt/venv && python3 agent_server.py &
+AGENT_PID=$!
+sleep 2
+if kill -0 $AGENT_PID 2>/dev/null; then
+    echo "Agent server started (PID $AGENT_PID)"
+else
+    echo "WARNING: Agent server failed to start"
+fi
+
+echo ""
+echo "══════════════════════════════════════════════════════════"
+echo "  Browser VM ready"
+echo "  noVNC: http://localhost:6080/vnc.html"
+echo "  Agent: http://localhost:8090"
+echo "══════════════════════════════════════════════════════════"
+
+wait

--- a/03-demos/deal-desk-agent/computer-use/salesforce_browser_agent.py
+++ b/03-demos/deal-desk-agent/computer-use/salesforce_browser_agent.py
@@ -1,0 +1,555 @@
+"""
+Salesforce Browser Agent — Computer Use integration.
+Drives a live Salesforce instance via Claude's computer use API on Vertex AI.
+Runs inside a Docker container with a virtual desktop (Xvfb + Chrome + noVNC).
+
+On Vertex AI, computer_20250124 tool type is NOT supported.
+We use type: "custom" with a full input_schema instead.
+No anthropic-beta headers are supported on Vertex rawPredict.
+"""
+
+import os
+import json
+import base64
+import subprocess
+import logging
+import asyncio
+from datetime import datetime
+from typing import AsyncGenerator
+
+import httpx
+import google.auth
+import google.auth.transport.requests
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONFIG
+# ═══════════════════════════════════════════════════════════════════════════════
+
+PROJECT_ID = os.environ.get("PROJECT_ID", "cpe-slarbi-nvd-ant-demos")
+REGION = os.environ.get("REGION", "us-east5")
+SONNET_MODEL = os.environ.get("SONNET_MODEL", "claude-sonnet-4-6@default")
+SALESFORCE_URL = os.environ.get(
+    "SALESFORCE_URL",
+    "https://orgfarm-09257c3eee-dev-ed.develop.lightning.force.com"
+)
+
+# Computer use settings
+DISPLAY_WIDTH = int(os.environ.get("DISPLAY_WIDTH", 1280))
+DISPLAY_HEIGHT = int(os.environ.get("DISPLAY_HEIGHT", 800))
+SCREENSHOT_PATH = "/tmp/screenshot.png"
+MAX_ITERATIONS = int(os.environ.get("CU_MAX_ITERATIONS", 40))
+
+# Vertex AI endpoint
+VERTEX_ENDPOINT = (
+    f"https://{REGION}-aiplatform.googleapis.com/v1/"
+    f"projects/{PROJECT_ID}/locations/{REGION}/"
+    f"publishers/anthropic/models/{SONNET_MODEL}:rawPredict"
+)
+
+logger = logging.getLogger("salesforce-browser-agent")
+logging.basicConfig(level=logging.DEBUG)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# AUTH
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def get_access_token() -> str:
+    """Get a fresh GCP access token via ADC."""
+    credentials, _ = google.auth.default()
+    credentials.refresh(google.auth.transport.requests.Request())
+    return credentials.token
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SCREENSHOT + ACTION EXECUTION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def take_screenshot() -> str:
+    """Capture the virtual display and return base64-encoded PNG."""
+    subprocess.run(
+        ["scrot", "-o", SCREENSHOT_PATH],
+        env={**os.environ, "DISPLAY": ":1"},
+        check=True,
+        capture_output=True,
+    )
+    with open(SCREENSHOT_PATH, "rb") as f:
+        return base64.standard_b64encode(f.read()).decode("utf-8")
+
+
+def execute_action(action: dict) -> dict:
+    """
+    Execute a computer use action on the virtual desktop.
+    Supports: click, type, key, scroll, screenshot, move.
+    Returns a result dict.
+    """
+    action_type = action.get("action")
+    display_env = {**os.environ, "DISPLAY": ":1"}
+
+    try:
+        if action_type == "screenshot":
+            return {"type": "screenshot", "status": "ok"}
+
+        elif action_type == "click":
+            x = action.get("coordinate", [0, 0])[0]
+            y = action.get("coordinate", [0, 0])[1]
+            button = action.get("button", "left")
+            btn_flag = {"left": "1", "right": "3", "middle": "2"}.get(button, "1")
+            subprocess.run(
+                ["xdotool", "mousemove", str(x), str(y), "click", btn_flag],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "click", "x": x, "y": y, "button": button, "status": "ok"}
+
+        elif action_type == "double_click":
+            x = action.get("coordinate", [0, 0])[0]
+            y = action.get("coordinate", [0, 0])[1]
+            subprocess.run(
+                ["xdotool", "mousemove", str(x), str(y),
+                 "click", "--repeat", "2", "--delay", "100", "1"],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "double_click", "x": x, "y": y, "status": "ok"}
+
+        elif action_type == "type":
+            text = action.get("text", "")
+            subprocess.run(
+                ["xdotool", "type", "--clearmodifiers", "--delay", "25", text],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "type", "text": text[:50], "status": "ok"}
+
+        elif action_type == "key":
+            key = action.get("key", "")
+            subprocess.run(
+                ["xdotool", "key", key],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "key", "key": key, "status": "ok"}
+
+        elif action_type == "scroll":
+            x = action.get("coordinate", [640, 400])[0]
+            y = action.get("coordinate", [640, 400])[1]
+            direction = action.get("direction", "down")
+            amount = action.get("amount", 3)
+            btn = "5" if direction == "down" else "4"
+            subprocess.run(
+                ["xdotool", "mousemove", str(x), str(y)],
+                env=display_env, check=True, capture_output=True,
+            )
+            for _ in range(amount):
+                subprocess.run(
+                    ["xdotool", "click", btn],
+                    env=display_env, check=True, capture_output=True,
+                )
+            return {"type": "scroll", "direction": direction, "amount": amount, "status": "ok"}
+
+        elif action_type == "move":
+            x = action.get("coordinate", [0, 0])[0]
+            y = action.get("coordinate", [0, 0])[1]
+            subprocess.run(
+                ["xdotool", "mousemove", str(x), str(y)],
+                env=display_env, check=True, capture_output=True,
+            )
+            return {"type": "move", "x": x, "y": y, "status": "ok"}
+
+        elif action_type == "wait":
+            duration = action.get("duration", 2)
+            import time
+            time.sleep(duration)
+            return {"type": "wait", "duration": duration, "status": "ok"}
+
+        else:
+            return {"type": action_type, "status": "unsupported"}
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Action execution failed: {action_type} — {e}")
+        return {"type": action_type, "status": "error", "msg": str(e)}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CUSTOM COMPUTER USE TOOL DEFINITION (Vertex AI compatible)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+COMPUTER_TOOL = {
+    "type": "custom",
+    "name": "computer",
+    "description": (
+        f"Control a computer with a {DISPLAY_WIDTH}x{DISPLAY_HEIGHT} pixel screen. "
+        "The screen is display :1. You can perform mouse and keyboard actions. "
+        "After every action, a screenshot will be returned showing the result. "
+        "Coordinates are absolute pixel positions from top-left (0,0) to "
+        f"bottom-right ({DISPLAY_WIDTH},{DISPLAY_HEIGHT})."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "click", "double_click", "type", "key",
+                    "scroll", "screenshot", "move", "wait"
+                ],
+                "description": "The action to perform."
+            },
+            "coordinate": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "minItems": 2,
+                "maxItems": 2,
+                "description": "Pixel [x, y] coordinate for click, double_click, scroll, and move actions."
+            },
+            "text": {
+                "type": "string",
+                "description": "Text to type (for 'type' action)."
+            },
+            "key": {
+                "type": "string",
+                "description": "Key or combo to press (for 'key' action), e.g. 'Return', 'ctrl+a', 'Tab'."
+            },
+            "button": {
+                "type": "string",
+                "enum": ["left", "right", "middle"],
+                "description": "Mouse button for click action. Default: left."
+            },
+            "direction": {
+                "type": "string",
+                "enum": ["up", "down"],
+                "description": "Scroll direction."
+            },
+            "amount": {
+                "type": "integer",
+                "description": "Number of scroll clicks. Default: 3."
+            },
+            "duration": {
+                "type": "integer",
+                "description": "Seconds to wait (for 'wait' action). Default: 2."
+            }
+        },
+        "required": ["action"]
+    }
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VERTEX AI API CALL
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def call_claude_computer_use(
+    messages: list,
+    system_prompt: str,
+) -> dict:
+    """
+    Call Claude Sonnet 4.6 on Vertex AI with custom computer use tool.
+
+    Key Vertex AI constraints (discovered via /test-vertex diagnostic):
+    - NO anthropic-beta headers supported on Vertex rawPredict
+    - computer_20250124 tool type NOT supported on Vertex
+    - Must use type: "custom" with full input_schema
+    - Display dimensions go in tool description, not as tool fields
+    """
+    token = get_access_token()
+
+    payload = {
+        "anthropic_version": "vertex-2023-10-16",
+        "max_tokens": 4096,
+        "system": system_prompt,
+        "messages": messages,
+        "tools": [COMPUTER_TOOL],
+    }
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            VERTEX_ENDPOINT,
+            headers=headers,
+            json=payload,
+        )
+
+        if response.status_code != 200:
+            logger.error(f"Vertex AI {response.status_code}: {response.text}")
+
+        response.raise_for_status()
+        return response.json()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# AGENT LOOP
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def build_system_prompt(deal_package: dict) -> str:
+    """Build the system prompt with deal package context for the browser agent."""
+    return f"""You are a Salesforce operations agent controlling a browser on a {DISPLAY_WIDTH}x{DISPLAY_HEIGHT} pixel screen.
+Your job is to create a new Opportunity in Salesforce Lightning using the deal package data provided below.
+
+You have a "computer" tool that lets you interact with the screen. After each action, you'll receive a screenshot showing the result.
+
+AVAILABLE ACTIONS:
+- click: Click at [x, y] coordinate (left/right/middle button)
+- double_click: Double-click at [x, y] coordinate
+- type: Type text at current cursor position
+- key: Press a key or combo (e.g., "Return", "Tab", "ctrl+a")
+- scroll: Scroll up/down at [x, y] coordinate
+- screenshot: Take a screenshot without performing an action
+- move: Move cursor to [x, y] coordinate
+- wait: Wait N seconds for page load
+
+DEAL PACKAGE:
+- Client Name: {deal_package.get('client_name', 'Unknown')}
+- AUM: ${deal_package.get('aum_millions', 0)}M
+- Strategy: {deal_package.get('strategy', 'Unknown')}
+- Mandate Type: {deal_package.get('mandate_type', 'Unknown')}
+- Fee Structure: {deal_package.get('fee_structure', 'Unknown')}
+- Compliance Status: {deal_package.get('compliance_status', 'Unknown')}
+- Risk Tier: {deal_package.get('risk_tier', 'Unknown')}
+- Primary Contact: {deal_package.get('primary_contact', 'Unknown')}
+- Primary Contact Title: {deal_package.get('primary_contact_title', 'Unknown')}
+- Deal ID: {deal_package.get('deal_id', 'Unknown')}
+
+SALESFORCE URL: {SALESFORCE_URL}
+
+INSTRUCTIONS:
+1. You should see the Salesforce Lightning interface in the browser.
+2. Navigate to the Sales app if not already there.
+3. Click "New" to create a new Opportunity.
+4. Fill in these fields:
+   - Opportunity Name: "{deal_package.get('client_name', 'Unknown')} — {deal_package.get('mandate_type', 'New Mandate')}"
+   - Close Date: Set to 30 days from today
+   - Stage: "Negotiation"
+   - Amount: {deal_package.get('aum_millions', 0)}000000
+5. Fill in any additional fields visible on the form.
+6. Click Save.
+7. After saving, take a screenshot to verify the Opportunity was created.
+8. Report the Opportunity name and any ID visible on the page.
+
+IMPORTANT:
+- Work carefully and methodically.
+- If a page is loading, wait a moment and take another screenshot.
+- If you encounter an error, try an alternative approach.
+- Do NOT navigate away from Salesforce.
+- When you are done, include the text "TASK_COMPLETE" in your response."""
+
+
+async def run_salesforce_agent(
+    deal_package: dict,
+) -> AsyncGenerator[dict, None]:
+    """
+    Run the Salesforce browser agent loop.
+    Yields SSE-compatible event dicts as the agent progresses.
+    """
+    system_prompt = build_system_prompt(deal_package)
+    messages = []
+    iteration = 0
+
+    yield {
+        "type": "agent_start",
+        "agent": "salesforce_agent",
+        "msg": "Browser agent activating — connecting to Salesforce...",
+    }
+
+    # Take initial screenshot
+    try:
+        screenshot_b64 = take_screenshot()
+    except Exception as e:
+        yield {
+            "type": "error",
+            "agent": "salesforce_agent",
+            "msg": f"Failed to capture initial screenshot: {e}",
+        }
+        return
+
+    # Start conversation with initial screenshot
+    messages.append({
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": "Here is the current state of the screen. Please create the Salesforce Opportunity using the deal package data.",
+            },
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": screenshot_b64,
+                },
+            },
+        ],
+    })
+
+    yield {
+        "type": "tool_call",
+        "agent": "salesforce_agent",
+        "tool": "screenshot",
+        "msg": "Captured Salesforce dashboard",
+    }
+
+    while iteration < MAX_ITERATIONS:
+        iteration += 1
+        logger.info(f"Salesforce agent — iteration {iteration}")
+
+        # Call Claude with current conversation
+        try:
+            response = await call_claude_computer_use(messages, system_prompt)
+        except httpx.HTTPStatusError as e:
+            yield {
+                "type": "error",
+                "agent": "salesforce_agent",
+                "msg": f"Vertex AI {e.response.status_code}: {e.response.text[:500]}",
+            }
+            return
+        except Exception as e:
+            yield {
+                "type": "error",
+                "agent": "salesforce_agent",
+                "msg": f"Vertex AI call failed: {e}",
+            }
+            return
+
+        # Process response content blocks
+        assistant_content = response.get("content", [])
+        messages.append({"role": "assistant", "content": assistant_content})
+
+        # Check for task completion or tool use
+        has_tool_use = False
+        task_complete = False
+        tool_results = []
+
+        for block in assistant_content:
+            block_type = block.get("type")
+
+            if block_type == "text":
+                text = block.get("text", "")
+                if "TASK_COMPLETE" in text:
+                    task_complete = True
+                    yield {
+                        "type": "agent_output",
+                        "agent": "salesforce_agent",
+                        "msg": text[:500],
+                    }
+
+            elif block_type == "tool_use":
+                has_tool_use = True
+                tool_input = block.get("input", {})
+                tool_id = block.get("id")
+                action_type = tool_input.get("action", "unknown")
+
+                # Emit event for the frontend
+                action_desc = _describe_action(tool_input)
+                yield {
+                    "type": "tool_call",
+                    "agent": "salesforce_agent",
+                    "tool": "computer_use",
+                    "msg": action_desc,
+                }
+
+                # Execute the action
+                result = execute_action(tool_input)
+
+                # Small delay for UI responsiveness
+                await asyncio.sleep(0.5)
+
+                # Take a new screenshot after the action
+                try:
+                    screenshot_b64 = take_screenshot()
+                except Exception as e:
+                    logger.error(f"Screenshot failed: {e}")
+                    screenshot_b64 = None
+
+                # Build tool result
+                tool_result_content = []
+                if screenshot_b64:
+                    tool_result_content.append({
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": screenshot_b64,
+                        },
+                    })
+
+                if result.get("status") == "error":
+                    tool_result_content.append({
+                        "type": "text",
+                        "text": f"Action failed: {result.get('msg', 'unknown error')}",
+                    })
+
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": tool_id,
+                    "content": tool_result_content,
+                })
+
+                yield {
+                    "type": "tool_result",
+                    "agent": "salesforce_agent",
+                    "tool": "computer_use",
+                    "msg": f"Action executed: {action_type} — {result.get('status')}",
+                }
+
+        if task_complete:
+            yield {
+                "type": "agent_complete",
+                "agent": "salesforce_agent",
+                "msg": "Salesforce Opportunity created and verified",
+            }
+            return
+
+        if has_tool_use and tool_results:
+            messages.append({"role": "user", "content": tool_results})
+        elif not has_tool_use:
+            # Model responded with text only, no tool use — done
+            yield {
+                "type": "agent_complete",
+                "agent": "salesforce_agent",
+                "msg": "Salesforce agent finished",
+            }
+            return
+
+    # Max iterations reached
+    yield {
+        "type": "agent_complete",
+        "agent": "salesforce_agent",
+        "msg": f"Max iterations ({MAX_ITERATIONS}) reached — review Salesforce manually",
+    }
+
+
+def _describe_action(tool_input: dict) -> str:
+    """Create a human-readable description of a computer use action."""
+    action = tool_input.get("action", "unknown")
+
+    if action == "click":
+        coords = tool_input.get("coordinate", [0, 0])
+        return f"Click at ({coords[0]}, {coords[1]})"
+
+    elif action == "double_click":
+        coords = tool_input.get("coordinate", [0, 0])
+        return f"Double-click at ({coords[0]}, {coords[1]})"
+
+    elif action == "type":
+        text = tool_input.get("text", "")
+        display = text[:60] + "..." if len(text) > 60 else text
+        return f'Type: "{display}"'
+
+    elif action == "key":
+        return f"Press key: {tool_input.get('key', '')}"
+
+    elif action == "scroll":
+        direction = tool_input.get("direction", "down")
+        return f"Scroll {direction}"
+
+    elif action == "screenshot":
+        return "Capture screenshot"
+
+    elif action == "move":
+        coords = tool_input.get("coordinate", [0, 0])
+        return f"Move cursor to ({coords[0]}, {coords[1]})"
+
+    elif action == "wait":
+        return f"Wait {tool_input.get('duration', 2)}s for page load"
+
+    return f"Action: {action}"

--- a/03-demos/deal-desk-agent/computer-use/supervisord.conf
+++ b/03-demos/deal-desk-agent/computer-use/supervisord.conf
@@ -1,0 +1,24 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord.log
+
+[program:xvfb]
+command=Xvfb :1 -screen 0 %(ENV_DISPLAY_WIDTH)sx%(ENV_DISPLAY_HEIGHT)sx24 -ac +extension GLX +render -noreset
+autorestart=true
+priority=10
+
+[program:fluxbox]
+command=fluxbox
+environment=DISPLAY=":1"
+autorestart=true
+priority=20
+
+[program:x11vnc]
+command=x11vnc -display :1 -forever -nopw -shared -rfbport 5900 -quiet
+autorestart=true
+priority=30
+
+[program:novnc]
+command=websockify --web=/usr/share/novnc 6080 localhost:5900
+autorestart=true
+priority=40

--- a/03-demos/deal-desk-agent/deploy/agent_engine_deploy.py
+++ b/03-demos/deal-desk-agent/deploy/agent_engine_deploy.py
@@ -1,0 +1,95 @@
+"""
+Deploy Deal Desk Agent to Vertex AI Agent Engine.
+Uses the ADK pipeline with Claude on Vertex AI.
+"""
+
+import os
+import sys
+
+# Add backend to path so we can import the agent
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+# Set required env vars before importing agent
+os.environ["GOOGLE_CLOUD_PROJECT"] = "cpe-slarbi-nvd-ant-demos"
+os.environ["GOOGLE_CLOUD_LOCATION"] = "us-east5"
+os.environ["PROJECT_ID"] = "cpe-slarbi-nvd-ant-demos"
+os.environ["REGION"] = "us-east5"
+os.environ["BQ_DATASET"] = "deal_desk_agent"
+os.environ["MODEL_PROVIDER"] = "claude"
+os.environ["OPUS_MODEL"] = "claude-opus-4-5@20251101"
+os.environ["SONNET_MODEL"] = "claude-sonnet-4-6@default"
+os.environ["HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
+
+import vertexai
+from vertexai import agent_engines
+from agents import deal_desk_pipeline
+
+PROJECT_ID = "cpe-slarbi-nvd-ant-demos"
+LOCATION = "us-central1"
+STAGING_BUCKET = "gs://cpe-slarbi-nvd-ant-demos-agent-staging"
+
+print("═" * 60)
+print("  Deal Desk Agent — Agent Engine Deployment")
+print(f"  Project:  {PROJECT_ID}")
+print(f"  Location: {LOCATION}")
+print(f"  Staging:  {STAGING_BUCKET}")
+print("═" * 60)
+
+# Initialize Vertex AI
+vertexai.init(project=PROJECT_ID, location=LOCATION)
+
+# Wrap in AdkApp
+print("\n📦 Wrapping agent in AdkApp...")
+app = agent_engines.AdkApp(
+    agent=deal_desk_pipeline,
+    enable_tracing=True,
+)
+
+# Test locally first
+print("🧪 Testing locally...")
+try:
+    for event in app.stream_query(
+        user_id="test-user",
+        message="hello",
+    ):
+        print(f"  Event: {type(event).__name__}")
+    print("✅ Local test passed")
+except Exception as e:
+    print(f"⚠️  Local test error (may be expected for Claude): {e}")
+
+# Deploy
+print("\n🚀 Deploying to Agent Engine (this takes 5-10 minutes)...")
+client = vertexai.Client(project=PROJECT_ID, location=LOCATION)
+
+remote_agent = client.agent_engines.create(
+    agent=app,
+    config={
+        "requirements": [
+            "cloudpickle>=3.0.0",
+            "pydantic>=2.0.0",
+            "google-cloud-aiplatform[agent_engines,adk]",
+            "google-adk>=1.2.0",
+            "anthropic[vertex]>=0.43.0",
+            "google-cloud-bigquery>=3.27.0",
+        ],
+        "staging_bucket": STAGING_BUCKET,
+        "display_name": "Deal Desk Agent",
+        "description": "FSI Deal Desk pipeline — Claude on Vertex AI + ADK",
+        "service_account": f"deal-desk-agent-sa@{PROJECT_ID}.iam.gserviceaccount.com",
+    },
+)
+
+print(f"\n✅ Agent Engine deployed!")
+print(f"   Resource: {remote_agent.api_resource}")
+print(f"   Operations: {remote_agent.operation_schemas()}")
+
+# Save resource info
+import json
+output = {
+    "resource_name": str(remote_agent.api_resource),
+    "project": PROJECT_ID,
+    "location": LOCATION,
+}
+with open(os.path.join(os.path.dirname(__file__), "agent_engine_output.json"), "w") as f:
+    json.dump(output, f, indent=2)
+print(f"   Saved to: deploy/agent_engine_output.json")

--- a/03-demos/deal-desk-agent/deploy/deploy.sh
+++ b/03-demos/deal-desk-agent/deploy/deploy.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+set -euo pipefail
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Deal Desk Agent — Deploy to Google Cloud
+# Builds all containers and deploys to Cloud Run + GCE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ─── Colors ───
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+step()  { echo -e "\n${BLUE}═══ Step $1: $2 ═══${NC}"; }
+ok()    { echo -e "${GREEN}✅ $1${NC}"; }
+warn()  { echo -e "${YELLOW}⚠️  $1${NC}"; }
+err()   { echo -e "${RED}❌ $1${NC}"; exit 1; }
+
+# ─── Config ───
+PROJECT_ID="${PROJECT_ID:-cpe-slarbi-nvd-ant-demos}"
+REGION="${REGION:-us-east5}"
+INFRA_REGION="${INFRA_REGION:-us-central1}"
+AR_REPO="deal-desk-agent"
+BACKEND_IMAGE="${INFRA_REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/backend"
+FRONTEND_IMAGE="${INFRA_REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/frontend"
+BROWSER_IMAGE="${INFRA_REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/browser-vm"
+
+echo "══════════════════════════════════════════════════════════════"
+echo "  Deal Desk Agent — Deployment"
+echo "  Project:  ${PROJECT_ID}"
+echo "  Model Region: ${REGION}"
+echo "  Infra Region: ${INFRA_REGION}"
+echo "══════════════════════════════════════════════════════════════"
+
+read -p "$(echo -e "${YELLOW}Deploy to ${PROJECT_ID}? (y/N): ${NC}")" confirm
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Cancelled."; exit 0
+fi
+
+gcloud config set project "$PROJECT_ID" --quiet
+
+# ─── Step 1: Enable APIs ───
+step "1/8" "Enabling APIs"
+gcloud services enable \
+    aiplatform.googleapis.com \
+    bigquery.googleapis.com \
+    run.googleapis.com \
+    cloudbuild.googleapis.com \
+    artifactregistry.googleapis.com \
+    compute.googleapis.com \
+    --quiet
+ok "APIs enabled"
+
+# ─── Step 2: Create Artifact Registry ───
+step "2/8" "Creating Artifact Registry repo"
+if gcloud artifacts repositories describe "$AR_REPO" --location="$INFRA_REGION" &>/dev/null 2>&1; then
+    warn "Repo already exists: ${AR_REPO}"
+else
+    gcloud artifacts repositories create "$AR_REPO" \
+        --repository-format=docker \
+        --location="$INFRA_REGION" \
+        --description="Deal Desk Agent containers" \
+        --quiet
+    ok "Repo created: ${AR_REPO}"
+fi
+
+# Configure Docker auth
+gcloud auth configure-docker "${INFRA_REGION}-docker.pkg.dev" --quiet
+ok "Docker auth configured"
+
+# ─── Step 3: Create Service Account ───
+step "3/8" "Creating service account"
+SA_NAME="deal-desk-agent-sa"
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+if gcloud iam service-accounts describe "$SA_EMAIL" &>/dev/null 2>&1; then
+    warn "Service account already exists"
+else
+    gcloud iam service-accounts create "$SA_NAME" \
+        --display-name="Deal Desk Agent Service Account" \
+        --quiet
+    ok "Service account created"
+fi
+
+# Bind roles
+for role in roles/aiplatform.user roles/bigquery.dataEditor roles/bigquery.jobUser; do
+    gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+        --member="serviceAccount:${SA_EMAIL}" \
+        --role="$role" \
+        --condition=None --quiet 2>/dev/null
+done
+ok "IAM roles bound"
+
+# ─── Step 4: Build Backend ───
+step "4/8" "Building backend container"
+cd "$(dirname "$0")/../backend"
+gcloud builds submit \
+    --tag="${BACKEND_IMAGE}:latest" \
+    --region="$INFRA_REGION" \
+    --quiet
+ok "Backend image built"
+
+# ─── Step 5: Build Frontend ───
+step "5/8" "Building frontend container"
+cd "$(dirname "$0")/../frontend"
+gcloud builds submit \
+    --tag="${FRONTEND_IMAGE}:latest" \
+    --region="$INFRA_REGION" \
+    --quiet
+ok "Frontend image built"
+
+# ─── Step 6: Build Browser VM ───
+step "6/8" "Building browser VM container"
+cd "$(dirname "$0")/../computer-use"
+gcloud builds submit \
+    --tag="${BROWSER_IMAGE}:latest" \
+    --region="$INFRA_REGION" \
+    --quiet
+ok "Browser VM image built"
+
+# ─── Step 7: Deploy Backend to Cloud Run ───
+step "7/8" "Deploying backend to Cloud Run"
+gcloud run deploy deal-desk-backend \
+    --image="${BACKEND_IMAGE}:latest" \
+    --region="$INFRA_REGION" \
+    --service-account="$SA_EMAIL" \
+    --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${REGION},BQ_DATASET=deal_desk_agent,MODEL_PROVIDER=claude,OPUS_MODEL=claude-opus-4-5@20251101,SONNET_MODEL=claude-sonnet-4-6@default,HAIKU_MODEL=claude-haiku-4-5@20251001" \
+    --memory=2Gi \
+    --cpu=2 \
+    --timeout=300 \
+    --max-instances=5 \
+    --allow-unauthenticated \
+    --quiet
+
+BACKEND_URL=$(gcloud run services describe deal-desk-backend --region="$INFRA_REGION" --format="value(status.url)")
+ok "Backend deployed: ${BACKEND_URL}"
+
+# ─── Step 8: Deploy Frontend to Cloud Run ───
+step "8/8" "Deploying frontend to Cloud Run"
+
+# Rebuild frontend with backend URL injected
+cd "$(dirname "$0")/../frontend"
+gcloud run deploy deal-desk-frontend \
+    --image="${FRONTEND_IMAGE}:latest" \
+    --region="$INFRA_REGION" \
+    --set-env-vars="API_BASE=${BACKEND_URL}" \
+    --memory=512Mi \
+    --cpu=1 \
+    --max-instances=3 \
+    --allow-unauthenticated \
+    --quiet
+
+FRONTEND_URL=$(gcloud run services describe deal-desk-frontend --region="$INFRA_REGION" --format="value(status.url)")
+ok "Frontend deployed: ${FRONTEND_URL}"
+
+# ─── Summary ───
+echo ""
+echo "══════════════════════════════════════════════════════════════"
+echo "  ✅ Deal Desk Agent — Deployment Complete"
+echo "══════════════════════════════════════════════════════════════"
+echo ""
+echo "  Frontend:    ${FRONTEND_URL}"
+echo "  Backend API: ${BACKEND_URL}"
+echo "  Health:      ${BACKEND_URL}/api/health"
+echo "  Agent Card:  ${BACKEND_URL}/.well-known/agent.json"
+echo ""
+echo "  Browser VM requires manual setup on GCE:"
+echo "  Image: ${BROWSER_IMAGE}:latest"
+echo "  Ports: 6080 (noVNC), 5900 (VNC)"
+echo ""
+echo "  To deploy Browser VM on GCE:"
+echo "  gcloud compute instances create-with-container deal-desk-browser \\"
+echo "    --container-image=${BROWSER_IMAGE}:latest \\"
+echo "    --zone=${INFRA_REGION}-a \\"
+echo "    --machine-type=e2-standard-4 \\"
+echo "    --tags=deal-desk-browser \\"
+echo "    --container-env=SALESFORCE_URL=https://orgfarm-53f3fee654.lightning.force.com"
+echo ""
+echo "══════════════════════════════════════════════════════════════"

--- a/03-demos/deal-desk-agent/docker-compose.yaml
+++ b/03-demos/deal-desk-agent/docker-compose.yaml
@@ -1,0 +1,44 @@
+# Deal Desk Agent — Local Development Stack
+# Usage: docker compose up --build
+# Access: Frontend at http://localhost:3000, noVNC at http://localhost:6080
+
+services:
+  # ─── FastAPI Backend ───
+  backend:
+    build: ./backend
+    ports:
+      - "8080:8080"
+    env_file: .env
+    environment:
+      - PORT=8080
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json
+    volumes:
+      - ${GOOGLE_APPLICATION_CREDENTIALS:-~/.config/gcloud/application_default_credentials.json}:/app/credentials.json:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # ─── React Frontend ───
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:8080"
+    depends_on:
+      backend:
+        condition: service_healthy
+
+  # ─── Browser VM (Computer Use) ───
+  browser-vm:
+    build: ./computer-use
+    ports:
+      - "6080:6080"
+      - "5900:5900"
+    env_file: .env
+    environment:
+      - DISPLAY_WIDTH=1280
+      - DISPLAY_HEIGHT=800
+    volumes:
+      - ${GOOGLE_APPLICATION_CREDENTIALS:-~/.config/gcloud/application_default_credentials.json}:/app/credentials.json:ro
+    shm_size: "2gb"

--- a/03-demos/deal-desk-agent/frontend/Dockerfile
+++ b/03-demos/deal-desk-agent/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/03-demos/deal-desk-agent/frontend/index.html
+++ b/03-demos/deal-desk-agent/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deal Desk Agent — Anthropic + Google Cloud</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%231a73e8'/><path d='M25 50l20 20 30-30' stroke='white' stroke-width='10' stroke-linecap='round' stroke-linejoin='round' fill='none'/></svg>" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/03-demos/deal-desk-agent/frontend/nginx.conf
+++ b/03-demos/deal-desk-agent/frontend/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 8080;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/03-demos/deal-desk-agent/frontend/package.json
+++ b/03-demos/deal-desk-agent/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "deal-desk-agent-ui",
+  "version": "1.0.0",
+  "description": "Deal Desk Agent — Booth Demo UI for Google Cloud NEXT 2026",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.3.1"
+  }
+}

--- a/03-demos/deal-desk-agent/frontend/src/App.jsx
+++ b/03-demos/deal-desk-agent/frontend/src/App.jsx
@@ -1,0 +1,541 @@
+import { useState, useEffect, useRef } from "react";
+import Markdown from "./Markdown.jsx";
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   CONFIG
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+const API_BASE = "https://deal-desk-backend-qrr3gkz3tq-uc.a.run.app";
+const NOVNC_URL = window.NOVNC_URL || "http://localhost:6080/vnc.html?autoconnect=true&resize=scale";
+
+const PRESETS = [
+  { label: "New Client Onboarding", prompt: "Onboard new client: ACME Capital Management. $250M AUM, long/short equity mandate, 2/20 fee structure, institutional investor. Primary contact: Sarah Chen, CIO. Run compliance checks and create the Salesforce opportunity." },
+  { label: "Portfolio Rebalance", prompt: "Process portfolio rebalance for Meridian Partners. Shift allocation from 60/40 equity/bond to 70/30. $180M AUM, moderate risk tolerance. Update Salesforce with new mandate details." },
+  { label: "Compliance Review", prompt: "Run full compliance review for Beacon Hedge Fund. $500M AUM, global macro strategy, Cayman domiciled. Check KYC/AML, FINRA registration, sanctions screening. Log results in Salesforce." },
+];
+
+const AGENTS = {
+  research_agent: { name: "Research Agent", model: "Opus 4.5", icon: "\u{1F50D}", color: "#059669" },
+  compliance_agent: { name: "Compliance Agent", model: "Sonnet 4.6", icon: "\u{1F6E1}", color: "#2563eb" },
+  risk_agent: { name: "Risk Scoring Agent", model: "Haiku 4.5", icon: "\u{1F4CA}", color: "#d97706" },
+  synthesis_agent: { name: "Synthesis Agent", model: "Opus 4.5", icon: "\u{1F9E0}", color: "#7c3aed" },
+  salesforce_agent: { name: "Salesforce Agent", model: "Sonnet 4.6", icon: "\u{1F310}", color: "#dc2626" },
+};
+
+const TOOL_ICONS = {
+  query_client_data: "\u{1F5C4}",
+  query_market_intelligence: "\u{1F4F0}",
+  query_compliance_records: "\u{1F4CB}",
+  compute_risk_score: "\u{2696}",
+  insert_deal_package: "\u{1F4BE}",
+  update_client_status: "\u{270F}",
+  computer_use: "\u{1F5B1}",
+  screenshot: "\u{1F4F8}",
+};
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   HEADER
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+function Header({ running, onReset }) {
+  return (
+    <header style={styles.header}>
+      <div style={styles.headerCenter}>
+        <svg width="28" height="28" viewBox="0 0 28 28" fill="none" style={{ marginRight: 10 }}>
+          <rect width="28" height="28" rx="6" fill="#1a73e8" />
+          <path d="M8 14l4 4 8-8" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        <div>
+          <h1 style={styles.title}>Deal Desk Agent</h1>
+          <p style={styles.subtitle}><strong>Anthropic + Google Cloud</strong> &mdash; <strong>Better Together</strong></p>
+        </div>
+      </div>
+      <div style={styles.headerRight}>
+        <span style={{ ...styles.chip, background: "#1a73e8", color: "#fff", fontWeight: 700 }}>Google Cloud NEXT 2026</span>
+        <span style={{ ...styles.chip, background: "#34a853", color: "#fff", fontWeight: 700 }}>Claude on Vertex AI</span>
+        <span style={{ ...styles.chip, background: "#ea4335", color: "#fff", fontWeight: 700 }}>Agent Development Kit</span>
+        <span style={{ ...styles.chip, background: "#fbbc04", color: "#1f2937", fontWeight: 700 }}>Computer Use API</span>
+        {running && <span style={styles.liveIndicator}><span style={styles.liveDot} /> Running</span>}
+        <button onClick={onReset} style={styles.resetBtn}>Reset</button>
+      </div>
+    </header>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   CHAT BUBBLE
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+function ChatMessage({ msg }) {
+  const isUser = msg.role === "user";
+  const isAgent = msg.role === "agent_event";
+
+  if (isAgent) {
+    const agentCfg = AGENTS[msg.agent] || { name: msg.agent, icon: "\u{2699}", color: "#6b7280" };
+    const toolIcon = TOOL_ICONS[msg.tool] || "\u{2699}";
+
+    if (msg.eventType === "agent_start") {
+      return (
+        <div style={styles.agentEventRow}>
+          <div style={{ ...styles.agentEventBadge, borderColor: agentCfg.color }}>
+            <span>{agentCfg.icon}</span>
+            <span style={{ fontWeight: 600, color: agentCfg.color }}>{agentCfg.name}</span>
+            <span style={styles.agentEventModel}>Claude {agentCfg.model} on Vertex AI</span>
+            <span style={styles.agentEventStatus}>activating...</span>
+          </div>
+        </div>
+      );
+    }
+    if (msg.eventType === "agent_complete") {
+      return (
+        <div style={styles.agentEventRow}>
+          <div style={{ ...styles.agentEventBadge, borderColor: agentCfg.color, background: "#f0fdf4" }}>
+            <span>{agentCfg.icon}</span>
+            <span style={{ fontWeight: 600, color: "#059669" }}>{agentCfg.name} — Complete</span>
+            <span style={{ color: "#059669", fontWeight: 600 }}>{"\u2713"}</span>
+          </div>
+        </div>
+      );
+    }
+    if (msg.eventType === "tool_call") {
+      return (
+        <div style={styles.toolEventRow}>
+          <div style={styles.toolEventLine} />
+          <div style={styles.toolEventContent}>
+            <span style={styles.toolEventIcon}>{toolIcon}</span>
+            <span style={styles.toolEventLabel}>CALL</span>
+            <span style={styles.toolEventMsg}><Markdown text={msg.msg} /></span>
+          </div>
+        </div>
+      );
+    }
+    if (msg.eventType === "tool_result") {
+      return (
+        <div style={styles.toolEventRow}>
+          <div style={styles.toolEventLine} />
+          <div style={{ ...styles.toolEventContent, background: "#f0fdf4" }}>
+            <span style={styles.toolEventIcon}>{"\u2705"}</span>
+            <span style={{ ...styles.toolEventLabel, color: "#059669" }}>RESULT</span>
+            <span style={styles.toolEventMsg}><Markdown text={msg.msg} /></span>
+          </div>
+        </div>
+      );
+    }
+    if (msg.eventType === "deal_package" || msg.eventType === "agent_output") {
+      return (
+        <div style={styles.assistantRow}>
+          <div style={styles.assistantBubble}>
+            <div style={styles.assistantHeader}>
+              <span>{agentCfg.icon}</span>
+              <span style={{ fontWeight: 600 }}>{agentCfg.name}</span>
+            </div>
+            <div style={styles.assistantText}><Markdown text={msg.msg} /></div>
+          </div>
+        </div>
+      );
+    }
+    if (msg.eventType === "pipeline_complete") {
+      return (
+        <div style={styles.agentEventRow}>
+          <div style={{ ...styles.pipelineComplete }}>
+            {"\u2705"} Pipeline complete — all agents finished
+          </div>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  if (msg.role === "assistant") {
+    return (
+      <div style={styles.assistantRow}>
+        <div style={styles.assistantBubble}>
+          <Markdown text={msg.text} />
+        </div>
+      </div>
+    );
+  }
+
+  if (isUser) {
+    return (
+      <div style={styles.userRow}>
+        <div style={styles.userBubble}>{msg.text}</div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   SALESFORCE PANEL
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+function SalesforcePanel({ active }) {
+  return (
+    <div style={styles.sfPanel}>
+      <div style={styles.sfHeader}>
+        <span style={{ width: 8, height: 8, borderRadius: "50%", background: active ? "#059669" : "#d1d5db" }} />
+        <span style={styles.sfTitle}>Live Salesforce View</span>
+        <span style={styles.sfBadge}>noVNC</span><a href="http://35.223.98.125:6080/vnc.html?autoconnect=true" target="_blank" rel="noopener" style={styles.newTabBtn}>Open in new tab 2197</a>
+      </div>
+      <div style={styles.sfBody}>
+        {active ? (
+          <div style={styles.sfPlaceholder}>
+            <div style={{ fontSize: 48, marginBottom: 16 }}>{"\u{1F310}"}</div>
+            <div style={{ fontSize: 16, fontWeight: 600, color: "#059669", marginBottom: 8 }}>Salesforce Agent Active</div>
+            <div style={{ fontSize: 14, color: "#6b7280", lineHeight: 1.6, maxWidth: 340, marginBottom: 20, textAlign: "center" }}>
+              Claude is navigating your Salesforce instance in real time. Click below to watch.
+            </div>
+            <a href="http://35.223.98.125:6080/vnc.html?autoconnect=true" target="_blank" rel="noopener"
+              style={{ display: "inline-block", padding: "12px 28px", fontSize: 15, fontWeight: 700, borderRadius: 8, background: "#1a73e8", color: "#ffffff", textDecoration: "none", cursor: "pointer" }}>
+              Watch Live in Salesforce {"\u2197"}
+            </a>
+          </div>
+        ) : (
+          <div style={styles.sfPlaceholder}>
+            <div style={{ fontSize: 48, opacity: 0.3, marginBottom: 16 }}>{"\u{1F5A5}"}</div>
+            <div style={{ fontSize: 16, fontWeight: 600, color: "#6b7280", marginBottom: 8 }}>Salesforce Browser</div>
+            <div style={{ fontSize: 14, color: "#9ca3af", lineHeight: 1.6, maxWidth: 300 }}>
+              The browser agent will activate here after the deal package is ready.
+              Claude will navigate Salesforce Lightning in real time.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   MAIN APP
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+export default function App() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState("");
+  const [running, setRunning] = useState(false);
+  const [sfActive, setSfActive] = useState(false);
+  const chatEndRef = useRef(null);
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const addMessage = (msg) => setMessages((prev) => [...prev, msg]);
+
+  const handleReset = async () => {
+    try { await fetch(`${API_BASE}/api/reset`, { method: "POST" }); } catch (e) {}
+    setMessages([]);
+    setRunning(false);
+    setSfActive(false);
+  };
+
+  const handleSubmit = (text) => {
+    if (!text.trim() || running) return;
+    const prompt = text.trim();
+    setInput("");
+    setRunning(true);
+
+    addMessage({ role: "user", text: prompt });
+
+    fetch(`${API_BASE}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt }),
+    }).then(async (response) => {
+      if (!response.ok) {
+        addMessage({ role: "agent_event", eventType: "agent_output", agent: "synthesis_agent", msg: `Error: ${response.status} ${response.statusText}` });
+        setRunning(false);
+        return;
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (line.startsWith("data: ")) {
+            try {
+              const evt = JSON.parse(line.slice(6));
+              handleEvent(evt);
+            } catch (e) {}
+          }
+        }
+      }
+      setRunning(false);
+    }).catch((err) => {
+      addMessage({ role: "agent_event", eventType: "agent_output", agent: "synthesis_agent", msg: `Connection error: ${err.message}` });
+      setRunning(false);
+    });
+  };
+
+  const handleEvent = (evt) => {
+    if (evt.agent === "salesforce_agent" && evt.type === "agent_start") setSfActive(true);
+    
+    // Clean conversational responses — no pipeline chrome
+    if (evt.type === "chat_response") {
+      addMessage({
+        role: "assistant",
+        text: evt.msg || "",
+      });
+      setRunning(false);
+      return;
+    }
+
+    addMessage({
+      role: "agent_event",
+      eventType: evt.type,
+      agent: evt.agent || "unknown",
+      tool: evt.tool || null,
+      msg: evt.msg || "",
+    });
+  };
+
+  return (
+    <div style={styles.root}>
+      <Header running={running} onReset={handleReset} />
+
+      <div style={styles.mainLayout}>
+        {/* ─── LEFT: Chat Interface ─── */}
+        <div style={styles.chatPanel}>
+          {/* Preset buttons */}
+          <div style={styles.presetArea}>
+            <span style={styles.presetLabel}>Demo scenarios</span>
+            <div style={styles.presetBtns}>
+              {PRESETS.map((p, i) => (
+                <button key={i} onClick={() => handleSubmit(p.prompt)} disabled={running}
+                  style={{ ...styles.presetBtn, opacity: running ? 0.5 : 1, cursor: running ? "not-allowed" : "pointer" }}>
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Chat messages */}
+          <div style={styles.chatMessages}>
+            {messages.length === 0 && (
+              <div style={styles.emptyChat}>
+                <div style={{ fontSize: 40, opacity: 0.3, marginBottom: 12 }}>{"\u26A1"}</div>
+                <div style={{ fontSize: 15, color: "#9ca3af", textAlign: "center", lineHeight: 1.6 }}>
+                  Select a demo scenario above or type a message below.<br />
+                  The multi-agent pipeline will activate and stream results here.
+                </div>
+              </div>
+            )}
+            {messages.map((msg, i) => <ChatMessage key={i} msg={msg} />)}
+            <div ref={chatEndRef} />
+          </div>
+
+          {/* Input area */}
+          <div style={styles.inputArea}>
+            <input
+              style={styles.chatInput}
+              placeholder="Type a message or ask a follow-up question..."
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(input); }}
+              disabled={running}
+            />
+            <button onClick={() => handleSubmit(input)} disabled={running || !input.trim()}
+              style={{ ...styles.sendBtn, opacity: running || !input.trim() ? 0.5 : 1 }}>
+              Send
+            </button>
+          </div>
+        </div>
+
+        {/* ─── RIGHT: Salesforce Viewer ─── */}
+        <div style={styles.rightPanel}>
+          <SalesforcePanel active={sfActive} />
+        </div>
+      </div>
+
+      <footer style={styles.footer}>
+        <span>Google Cloud NEXT 2026</span>
+        <span style={styles.footerDot}>{"\u00B7"}</span>
+        <span>Claude on Vertex AI</span>
+        <span style={styles.footerDot}>{"\u00B7"}</span>
+        <span>Agent Development Kit</span>
+        <span style={styles.footerDot}>{"\u00B7"}</span>
+        <span>Computer Use API</span>
+      </footer>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   STYLES
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+const styles = {
+  root: {
+    fontFamily: "'Google Sans', 'Segoe UI', system-ui, sans-serif",
+    background: "#ffffff", height: "100vh", overflow: "hidden",
+    display: "flex", flexDirection: "column", color: "#1f2937",
+  },
+
+  /* Header */
+  header: {
+    display: "flex", alignItems: "center", justifyContent: "space-between",
+    padding: "12px 24px", borderBottom: "1px solid #e5e7eb", background: "#ffffff",
+  },
+  headerCenter: { display: "flex", alignItems: "center" },
+  headerRight: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" },
+  title: { fontSize: 18, fontWeight: 700, margin: 0, color: "#111827", textAlign: "center" },
+  subtitle: { fontSize: 12, margin: 0, color: "#4b5563" },
+  chip: {
+    fontSize: 11, fontWeight: 500, padding: "4px 12px", borderRadius: 100,
+    border: "none", whiteSpace: "nowrap",
+  },
+  liveIndicator: {
+    display: "flex", alignItems: "center", gap: 6,
+    fontSize: 12, fontWeight: 600, color: "#059669",
+  },
+  liveDot: {
+    width: 8, height: 8, borderRadius: "50%", background: "#059669",
+    display: "inline-block", animation: "pulse 1.5s ease-in-out infinite",
+  },
+  resetBtn: {
+    fontSize: 12, fontWeight: 600, padding: "5px 14px", borderRadius: 6,
+    border: "1px solid #d1d5db", background: "#ffffff", color: "#374151", cursor: "pointer",
+  },
+
+  /* Main Layout */
+  mainLayout: { display: "flex", flex: 1, overflow: "hidden" },
+  chatPanel: {
+    width: "55%", display: "flex", flexDirection: "column", minHeight: 0,
+    borderRight: "1px solid #e5e7eb", background: "#ffffff",
+  },
+  rightPanel: { width: "45%", display: "flex", flexDirection: "column", background: "#f9fafb" },
+
+  /* Presets */
+  presetArea: {
+    padding: "12px 20px", borderBottom: "1px solid #f3f4f6",
+    background: "#fafafa", display: "flex", alignItems: "center", gap: 12,
+  },
+  presetLabel: { fontSize: 12, fontWeight: 500, color: "#9ca3af", whiteSpace: "nowrap" },
+  presetBtns: { display: "flex", gap: 8, flexWrap: "wrap" },
+  presetBtn: {
+    fontSize: 13, fontWeight: 500, padding: "6px 16px", borderRadius: 6,
+    border: "1px solid #d1d5db", background: "#ffffff", color: "#1f2937", cursor: "pointer",
+  },
+
+  /* Chat Messages */
+  chatMessages: { flex: 1, overflowY: "auto", padding: "16px 20px", display: "flex", flexDirection: "column", gap: 8, minHeight: 0 },
+  emptyChat: {
+    flex: 1, display: "flex", flexDirection: "column",
+    alignItems: "center", justifyContent: "center", padding: 40,
+  },
+
+  /* User bubble */
+  userRow: { display: "flex", justifyContent: "flex-end" },
+  userBubble: {
+    maxWidth: "70%", padding: "10px 16px", borderRadius: "16px 16px 4px 16px",
+    background: "#1a73e8", color: "#ffffff", fontSize: 14, lineHeight: 1.6,
+  },
+
+  /* Agent events */
+  agentEventRow: { display: "flex", justifyContent: "flex-start", padding: "4px 0" },
+  agentEventBadge: {
+    display: "flex", alignItems: "center", gap: 8, padding: "8px 14px",
+    borderRadius: 8, border: "1px solid", background: "#f9fafb", fontSize: 13,
+  },
+  agentEventModel: { fontSize: 11, color: "#9ca3af" },
+  agentEventStatus: { fontSize: 12, color: "#6b7280", fontStyle: "italic" },
+
+  /* Tool events */
+  toolEventRow: { display: "flex", alignItems: "center", gap: 8, paddingLeft: 24 },
+  toolEventLine: { width: 2, height: 28, background: "#e5e7eb", borderRadius: 1, flexShrink: 0 },
+  toolEventContent: {
+    display: "flex", alignItems: "center", gap: 6, padding: "5px 12px",
+    borderRadius: 6, background: "#f3f4f6", fontSize: 13, flex: 1,
+  },
+  toolEventIcon: { fontSize: 14, width: 20, textAlign: "center" },
+  toolEventLabel: {
+    fontSize: 10, fontWeight: 700, letterSpacing: "0.05em",
+    color: "#6b7280", textTransform: "uppercase", flexShrink: 0,
+  },
+  toolEventMsg: { color: "#374151", flex: 1 },
+
+  /* Assistant bubble */
+  assistantRow: { display: "flex", justifyContent: "flex-start" },
+  assistantBubble: {
+    maxWidth: "80%", padding: "12px 16px", borderRadius: "16px 16px 16px 4px",
+    background: "#f3f4f6", fontSize: 14, lineHeight: 1.6,
+  },
+  assistantHeader: { display: "flex", alignItems: "center", gap: 6, marginBottom: 6, fontSize: 13, fontWeight: 600 },
+  assistantText: { color: "#1f2937", whiteSpace: "pre-wrap" },
+
+  /* Pipeline complete */
+  pipelineComplete: {
+    padding: "10px 16px", borderRadius: 8, background: "#f0fdf4",
+    border: "1px solid #bbf7d0", color: "#166534", fontWeight: 600, fontSize: 14,
+  },
+
+  /* Input area */
+  inputArea: {
+    padding: "12px 20px", borderTop: "1px solid #e5e7eb",
+    display: "flex", gap: 10, background: "#ffffff",
+  },
+  chatInput: {
+    flex: 1, padding: "10px 16px", fontSize: 14, borderRadius: 24,
+    border: "1px solid #d1d5db", outline: "none", fontFamily: "inherit",
+    color: "#1f2937", background: "#f9fafb",
+  },
+  sendBtn: {
+    padding: "10px 24px", fontSize: 14, fontWeight: 600, borderRadius: 24,
+    border: "none", background: "#1a73e8", color: "#ffffff", cursor: "pointer",
+  },
+
+  /* Salesforce panel */
+  sfPanel: { display: "flex", flexDirection: "column", flex: 1 },
+  sfHeader: {
+    display: "flex", alignItems: "center", gap: 8,
+    padding: "10px 20px", borderBottom: "1px solid #e5e7eb", background: "#ffffff",
+  },
+  sfTitle: { fontSize: 13, fontWeight: 600, color: "#374151", flex: 1 },
+  sfBadge: {
+  newTabBtn: {
+    fontSize: 11, fontWeight: 600, padding: "3px 10px", borderRadius: 4,
+    background: "#1a73e8", color: "#ffffff", textDecoration: "none",
+    marginLeft: 6, cursor: "pointer",
+  },
+    fontSize: 10, fontWeight: 600, padding: "2px 8px", borderRadius: 4,
+    background: "#f3f4f6", color: "#6b7280", textTransform: "uppercase", letterSpacing: "0.05em",
+  },
+  sfBody: { flex: 1, display: "flex" },
+  sfIframe: { width: "100%", height: "100%", border: "none" },
+  sfPlaceholder: {
+    flex: 1, display: "flex", flexDirection: "column",
+    alignItems: "center", justifyContent: "center", padding: 40, textAlign: "center",
+  },
+
+  /* Footer */
+  footer: {
+    display: "flex", alignItems: "center", justifyContent: "center", gap: 8,
+    padding: "10px 24px", borderTop: "1px solid #e5e7eb",
+    fontSize: 12, fontWeight: 500, color: "#9ca3af", background: "#ffffff",
+  },
+  footerDot: { color: "#d1d5db" },
+};
+
+/* Global CSS */
+if (typeof document !== "undefined") {
+  const s = document.createElement("style");
+  s.textContent = `
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+    @import url('https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;600;700&display=swap');
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { margin: 0; background: #ffffff; }
+    input:focus { border-color: #1a73e8 !important; background: #ffffff !important; }
+    button:hover:not(:disabled) { filter: brightness(0.95); }
+  `;
+  document.head.appendChild(s);
+}

--- a/03-demos/deal-desk-agent/frontend/src/Markdown.jsx
+++ b/03-demos/deal-desk-agent/frontend/src/Markdown.jsx
@@ -1,0 +1,124 @@
+/**
+ * Lightweight markdown renderer — no external deps.
+ * Handles bold, headers, tables, lists, and horizontal rules.
+ */
+
+function parseLine(line) {
+  return line
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/`(.+?)`/g, '<code style="background:#f3f4f6;padding:1px 5px;border-radius:3px;font-size:12px">$1</code>');
+}
+
+function isTableRow(line) {
+  return line.trim().startsWith('|') && line.trim().endsWith('|');
+}
+
+function isSeparator(line) {
+  return /^\|[\s\-:|]+\|$/.test(line.trim());
+}
+
+function parseTable(lines) {
+  const rows = lines
+    .filter(l => !isSeparator(l))
+    .map(l => l.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map(c => c.trim()));
+
+  if (rows.length === 0) return '';
+  const header = rows[0];
+  const body = rows.slice(1);
+
+  return `<table style="width:100%;border-collapse:collapse;margin:8px 0;font-size:13px">
+    <thead><tr>${header.map(h => `<th style="text-align:left;padding:6px 10px;border-bottom:2px solid #e5e7eb;font-weight:600;color:#374151">${parseLine(h)}</th>`).join('')}</tr></thead>
+    <tbody>${body.map((row, i) => `<tr style="background:${i % 2 === 0 ? '#ffffff' : '#f9fafb'}">${row.map(c => `<td style="padding:5px 10px;border-bottom:1px solid #f3f4f6;color:#4b5563">${parseLine(c)}</td>`).join('')}</tr>`).join('')}</tbody>
+  </table>`;
+}
+
+export function renderMarkdown(text) {
+  if (!text) return '';
+  const lines = text.split('\n');
+  let html = '';
+  let i = 0;
+  let inTable = false;
+  let tableLines = [];
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Table
+    if (isTableRow(trimmed)) {
+      if (!inTable) { inTable = true; tableLines = []; }
+      tableLines.push(trimmed);
+      i++;
+      continue;
+    } else if (inTable) {
+      html += parseTable(tableLines);
+      inTable = false;
+      tableLines = [];
+    }
+
+    // Horizontal rule
+    if (/^-{3,}$/.test(trimmed) || /^\*{3,}$/.test(trimmed)) {
+      html += '<hr style="border:none;border-top:1px solid #e5e7eb;margin:10px 0" />';
+      i++;
+      continue;
+    }
+
+    // Headers
+    if (trimmed.startsWith('#### ')) {
+      html += `<div style="font-size:13px;font-weight:700;color:#374151;margin:10px 0 4px">${parseLine(trimmed.slice(5))}</div>`;
+      i++; continue;
+    }
+    if (trimmed.startsWith('### ')) {
+      html += `<div style="font-size:14px;font-weight:700;color:#111827;margin:12px 0 4px">${parseLine(trimmed.slice(4))}</div>`;
+      i++; continue;
+    }
+    if (trimmed.startsWith('## ')) {
+      html += `<div style="font-size:15px;font-weight:700;color:#111827;margin:14px 0 6px">${parseLine(trimmed.slice(3))}</div>`;
+      i++; continue;
+    }
+    if (trimmed.startsWith('# ')) {
+      html += `<div style="font-size:16px;font-weight:700;color:#111827;margin:16px 0 8px">${parseLine(trimmed.slice(2))}</div>`;
+      i++; continue;
+    }
+
+    // Blockquote
+    if (trimmed.startsWith('> ')) {
+      html += `<div style="border-left:3px solid #d1d5db;padding:4px 12px;margin:6px 0;color:#6b7280;font-style:italic">${parseLine(trimmed.slice(2))}</div>`;
+      i++; continue;
+    }
+
+    // List item
+    if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+      html += `<div style="display:flex;gap:6px;padding:2px 0"><span style="color:#9ca3af">•</span><span>${parseLine(trimmed.slice(2))}</span></div>`;
+      i++; continue;
+    }
+
+    // Numbered list
+    if (/^\d+\.\s/.test(trimmed)) {
+      const num = trimmed.match(/^(\d+)\.\s/)[1];
+      const content = trimmed.replace(/^\d+\.\s/, '');
+      html += `<div style="display:flex;gap:6px;padding:2px 0"><span style="color:#9ca3af;min-width:16px">${num}.</span><span>${parseLine(content)}</span></div>`;
+      i++; continue;
+    }
+
+    // Empty line
+    if (trimmed === '') {
+      html += '<div style="height:6px"></div>';
+      i++; continue;
+    }
+
+    // Regular paragraph
+    html += `<div style="padding:1px 0">${parseLine(trimmed)}</div>`;
+    i++;
+  }
+
+  // Flush remaining table
+  if (inTable) html += parseTable(tableLines);
+
+  return html;
+}
+
+export default function Markdown({ text }) {
+  return <div dangerouslySetInnerHTML={{ __html: renderMarkdown(text) }} />;
+}

--- a/03-demos/deal-desk-agent/frontend/src/main.jsx
+++ b/03-demos/deal-desk-agent/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.jsx";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/03-demos/deal-desk-agent/frontend/vite.config.js
+++ b/03-demos/deal-desk-agent/frontend/vite.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: "dist",
+    sourcemap: false,
+  },
+});


### PR DESCRIPTION
## Summary

Adds the **FSI Deal Desk Agent** demo to `03-demos/deal-desk-agent/` — a multi-agent client-onboarding pipeline built for **Google Cloud NEXT 2026** showcasing Claude on Vertex AI + Google ADK + Computer Use.

### What's in the demo

- **Backend** (`backend/`) — FastAPI on Cloud Run orchestrating the agent graph
- **Frontend** (`frontend/`) — React/Vite UI on Cloud Run
- **Computer Use VM** (`computer-use/`) — GCE container with Xvfb + Chrome + noVNC running a Claude-Sonnet-4.6 Salesforce browser agent
- **Agent Engine deploy** (`agent_deploy/`, `deploy/`) — ADK Agent Engine + Terraform
- **Engineering design doc** (`DESIGN.md`) — architecture, security model, known limitations

### Agents and models

| Agent | Model | Role |
|-------|-------|------|
| Research | Opus 4.5 | Client + market intelligence |
| Compliance | Sonnet 4.6 | KYC / AML / sanctions |
| Risk | Haiku 4.5 | Quantitative risk scoring |
| Synthesis | Opus 4.5 | Deal package assembly |
| Salesforce | Sonnet 4.6 (Computer Use) | Browser-based CRM entry |

Region: `us-east5`. GCP services: Vertex AI, BigQuery, Cloud Run, Compute Engine, Artifact Registry, Agent Engine, ADK.

### Index

`03-demos/README.md` updated with a one-line entry for this demo, linking both the README and the engineering design doc.

## Disclaimer

This is **not production-ready software** and is **not supported**. It is single-tenant, drives a Salesforce Developer Edition sandbox, uses in-memory ADK sessions, and carries the known limitations documented in `DESIGN.md` §9. Sample BigQuery data is synthetic. **Do not deploy against real client data, production Salesforce orgs, or regulated workloads.** See the README for the full disclaimer and `DESIGN.md` §10 for the security model.

## Test plan

- [ ] Reviewer browses `03-demos/deal-desk-agent/README.md` and confirms architecture, models, and disclaimer render correctly
- [ ] Reviewer skims `DESIGN.md` for the auth/security model (§5) and known limitations (§9)
- [ ] Confirm `.env.example` templates contain only placeholders (no real secrets)
- [ ] Confirm `03-demos/README.md` index entry links resolve