### PR TITLE
Fix A2A agent card URL and restore .env.example templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 venv/
 .env
 .env.*
+!.env.example
 node_modules/
 .DS_Store
 .idea/

--- a/03-demos/deal-desk-agent/.env.example
+++ b/03-demos/deal-desk-agent/.env.example
@@ -1,0 +1,34 @@
+# ─── GCP Configuration ───
+PROJECT_ID=your-gcp-project-id
+REGION=us-east5
+BQ_DATASET=deal_desk_agent
+
+# ─── Claude Models on Vertex AI ───
+# Instructors / deploy operators will provide the exact pinned versions.
+OPUS_MODEL=claude-opus-4-5@YYYYMMDD
+SONNET_MODEL=claude-sonnet-4-6@default
+HAIKU_MODEL=claude-haiku-4-5@YYYYMMDD
+
+# ─── Salesforce ───
+# Your Salesforce Developer Edition org URL.
+SALESFORCE_URL=https://your-org.develop.lightning.force.com
+
+# ─── Model Toggle (claude or gemini) ───
+MODEL_PROVIDER=claude
+
+# ─── Shared Secret for Backend ↔ Browser VM ───
+# Generate with: openssl rand -hex 32 > .agent-secret
+# Load into this env with: AGENT_SECRET=$(cat .agent-secret)
+# NEVER commit the real value.
+AGENT_SECRET=replace-with-output-of-openssl-rand-hex-32
+
+# ─── Browser VM ───
+# The static external IP:port of the GCE browser VM running agent_server.
+BROWSER_AGENT_URL=http://YOUR.VM.STATIC.IP:8090
+
+# ─── A2A Agent Card URL (optional) ───
+# Public URL of this backend, advertised in the /.well-known/agent.json card so
+# Gemini Enterprise and other A2A clients know where to reach the agent.
+# If unset, the URL is derived from the incoming request — fine for most deploys.
+# Set this explicitly when registering with Gemini Enterprise so the card is stable.
+A2A_AGENT_URL=https://your-backend.run.app

--- a/03-demos/deal-desk-agent/agent_deploy/.env.example
+++ b/03-demos/deal-desk-agent/agent_deploy/.env.example
@@ -1,0 +1,16 @@
+# ADK requires these to be set BEFORE importing google.adk modules.
+# agent_deploy/agent.py uses os.environ.setdefault() for the same keys, but
+# populating them here keeps local runs consistent with Agent Engine deploys.
+
+GOOGLE_GENAI_USE_VERTEXAI=TRUE
+GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+GOOGLE_CLOUD_LOCATION=us-east5
+
+PROJECT_ID=your-gcp-project-id
+REGION=us-east5
+BQ_DATASET=deal_desk_agent
+
+MODEL_PROVIDER=claude
+OPUS_MODEL=claude-opus-4-5@YYYYMMDD
+SONNET_MODEL=claude-sonnet-4-6@default
+HAIKU_MODEL=claude-haiku-4-5@YYYYMMDD

--- a/03-demos/deal-desk-agent/backend/agents/agent_card.json
+++ b/03-demos/deal-desk-agent/backend/agents/agent_card.json
@@ -7,7 +7,7 @@
     "name": "Google Cloud — Partner Technical Architecture",
     "contact": "slarbi@google.com"
   },
-  "url": "https://deal-desk-agent-REGION-run.app",
+  "url": "set-at-runtime-via-A2A_AGENT_URL-env-var-or-derived-from-request",
   "protocol": "a2a/1.0",
   "capabilities": {
     "input": {

--- a/03-demos/deal-desk-agent/backend/main.py
+++ b/03-demos/deal-desk-agent/backend/main.py
@@ -974,13 +974,20 @@ async def chat(request: Request):
 # ═══════════════════════════════════════════════════════════════════════════════
 
 @app.get("/.well-known/agent.json")
-async def a2a_agent_card():
-    """Serve the A2A agent card for discovery."""
+async def a2a_agent_card(request: Request):
+    """Serve the A2A agent card for discovery.
+
+    URL resolution order:
+      1. A2A_AGENT_URL env var (preferred for stable deploys — set this to the
+         public Cloud Run URL when registering the agent with Gemini Enterprise)
+      2. Derived from the incoming request (works on any deploy out of the box)
+    """
+    a2a_url = os.environ.get("A2A_AGENT_URL") or f"{request.url.scheme}://{request.url.netloc}"
     return {
         "protocolVersion": "0.2.3",
         "name": "deal-desk-agent",
         "description": "End-to-end deal desk pipeline for FSI client onboarding. Powered by Claude on Vertex AI + Google ADK.",
-        "url": "https://deal-desk-backend-qrr3gkz3tq-uc.a.run.app",
+        "url": a2a_url,
         "version": "1.0.0",
         "defaultInputModes": ["text"],
         "defaultOutputModes": ["text"],


### PR DESCRIPTION
## Summary

Two cleanup fixes to the Deal Desk demo so it works on any deploy, not just the original demo project.

### A2A agent card URL

`backend/main.py` `/.well-known/agent.json` hardcoded an old Cloud Run URL (`deal-desk-backend-qrr3gkz3tq-uc.a.run.app`), and `backend/agents/agent_card.json` had a `REGION` placeholder. Both broke A2A discovery on every deploy other than the original demo project — Gemini Enterprise (or any A2A client) would resolve the agent card and then call the wrong URL.

- Endpoint now resolves the URL from `A2A_AGENT_URL` env var first, falling back to deriving it from the incoming request — works on any Cloud Run deploy out of the box. Set `A2A_AGENT_URL` explicitly when registering with Gemini Enterprise so the card is stable.
- `agent_card.json` placeholder updated to reflect the runtime resolution.
- `.env.example` documents the new variable.

### Restored .env.example templates

The initial PR's `.env.example` files were silently dropped from the merge: the root `.gitignore` had `.env.*` which matches `.env.example`. Added an explicit `!.env.example` exception so template files survive in this repo and any future demo can ship them.

## Test plan

- [ ] Read `03-demos/deal-desk-agent/backend/main.py` `a2a_agent_card` and confirm the URL-resolution fallback chain
- [ ] Confirm `03-demos/deal-desk-agent/.env.example` and `03-demos/deal-desk-agent/agent_deploy/.env.example` are present in the diff
- [ ] Confirm `.gitignore` change includes the `!.env.example` whitelist