### PR TITLE
Parameterize remaining hardcoded URLs (frontend runtime config + agent_deploy)

### DIFF
--- a/03-demos/deal-desk-agent/.env.example
+++ b/03-demos/deal-desk-agent/.env.example
@@ -32,3 +32,15 @@ BROWSER_AGENT_URL=http://YOUR.VM.STATIC.IP:8090
 # If unset, the URL is derived from the incoming request — fine for most deploys.
 # Set this explicitly when registering with Gemini Enterprise so the card is stable.
 A2A_AGENT_URL=https://your-backend.run.app
+
+# ─── Frontend Runtime Config (Cloud Run env vars on the frontend service) ───
+# The frontend container reads these at startup and writes them into /config.js
+# which the React app loads at runtime — no rebuild needed when the backend URL changes.
+API_BASE=https://your-backend.run.app
+NOVNC_URL=http://YOUR.VM.STATIC.IP:6080/vnc.html?autoconnect=true&resize=scale
+
+# ─── Agent Engine deployment (env vars passed to the deployed agent) ───
+# trigger_salesforce_opportunity in agent_deploy/tools.py routes through Cloud Run
+# (which holds AGENT_SECRET), so the deployed agent must know the backend URL.
+# BACKEND_URL is the same Cloud Run URL as A2A_AGENT_URL above.
+BACKEND_URL=https://your-backend.run.app

--- a/03-demos/deal-desk-agent/agent_deploy/tools.py
+++ b/03-demos/deal-desk-agent/agent_deploy/tools.py
@@ -347,8 +347,15 @@ def trigger_salesforce_opportunity(client_name: str) -> dict:
     """
     import httpx
 
-    BACKEND_URL = "https://deal-desk-backend-436293010210.us-central1.run.app"
-    NOVNC_URL = "http://35.223.98.125:6080/vnc.html?autoconnect=true"
+    BACKEND_URL = os.environ.get("BACKEND_URL", "")
+    NOVNC_URL = os.environ.get("NOVNC_URL", "")
+
+    if not BACKEND_URL:
+        return {
+            "success": False,
+            "error": "BACKEND_URL env var is not set on the Agent Engine deployment.",
+            "hint": "Pass BACKEND_URL (Cloud Run backend URL) when deploying to Agent Engine.",
+        }
 
     try:
         resp = httpx.post(

--- a/03-demos/deal-desk-agent/frontend/Dockerfile
+++ b/03-demos/deal-desk-agent/frontend/Dockerfile
@@ -6,7 +6,10 @@ COPY . .
 RUN npm run build
 
 FROM nginx:alpine
+RUN apk add --no-cache gettext
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 EXPOSE 8080
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/entrypoint.sh"]

--- a/03-demos/deal-desk-agent/frontend/entrypoint.sh
+++ b/03-demos/deal-desk-agent/frontend/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+: "${API_BASE:?API_BASE environment variable must be set (the public Cloud Run URL of the backend)}"
+: "${NOVNC_URL:=http://localhost:6080/vnc.html?autoconnect=true&resize=scale}"
+
+export API_BASE NOVNC_URL
+
+envsubst '$API_BASE $NOVNC_URL' \
+  < /usr/share/nginx/html/config.js.template \
+  > /usr/share/nginx/html/config.js
+
+echo "Frontend runtime config:"
+echo "  API_BASE=$API_BASE"
+echo "  NOVNC_URL=$NOVNC_URL"
+
+exec nginx -g 'daemon off;'

--- a/03-demos/deal-desk-agent/frontend/index.html
+++ b/03-demos/deal-desk-agent/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/config.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/03-demos/deal-desk-agent/frontend/public/config.js.template
+++ b/03-demos/deal-desk-agent/frontend/public/config.js.template
@@ -1,0 +1,6 @@
+// Runtime configuration — populated at container startup by entrypoint.sh.
+// Vite copies this file to dist/ verbatim; envsubst rewrites it to /config.js.
+window.__APP_CONFIG__ = {
+  API_BASE: "${API_BASE}",
+  NOVNC_URL: "${NOVNC_URL}"
+};

--- a/03-demos/deal-desk-agent/frontend/src/App.jsx
+++ b/03-demos/deal-desk-agent/frontend/src/App.jsx
@@ -5,8 +5,10 @@ import Markdown from "./Markdown.jsx";
    CONFIG
    ═══════════════════════════════════════════════════════════════════════════════ */
 
-const API_BASE = "https://deal-desk-backend-qrr3gkz3tq-uc.a.run.app";
-const NOVNC_URL = window.NOVNC_URL || "http://localhost:6080/vnc.html?autoconnect=true&resize=scale";
+// Runtime config — injected by nginx entrypoint via /config.js (see Dockerfile).
+// Falls back to localhost defaults so `npm run dev` still works against a local backend.
+const API_BASE = window.__APP_CONFIG__?.API_BASE || "http://localhost:8080";
+const NOVNC_URL = window.__APP_CONFIG__?.NOVNC_URL || "http://localhost:6080/vnc.html?autoconnect=true&resize=scale";
 
 const PRESETS = [
   { label: "New Client Onboarding", prompt: "Onboard new client: ACME Capital Management. $250M AUM, long/short equity mandate, 2/20 fee structure, institutional investor. Primary contact: Sarah Chen, CIO. Run compliance checks and create the Salesforce opportunity." },


### PR DESCRIPTION
## Summary

Final cleanup PR before adding the Colab Enterprise deploy notebook. Two more places in the demo carried hardcoded URLs from the original deploy that broke any reuse in a fresh project — preventing the upcoming notebook from working out of the box.

### Frontend — runtime config injection

The React app hardcoded `API_BASE` to a specific Cloud Run URL. Even with Vite's build-time env injection, that meant a rebuild for every redeploy.

Switched to a runtime-injection pattern that's standard for containerized SPAs:
- `App.jsx` reads `API_BASE` and `NOVNC_URL` from `window.__APP_CONFIG__`, with localhost fallbacks for `npm run dev`
- `public/config.js.template` carries `${API_BASE}` and `${NOVNC_URL}` placeholders; Vite copies it into the build output
- `entrypoint.sh` runs `envsubst` on the template at container startup and writes `/config.js`
- `index.html` loads `/config.js` before `main.jsx`
- `Dockerfile` installs `gettext` (for envsubst) and runs the entrypoint instead of nginx directly

Result: the **same image** redeploys to any backend URL — no rebuild needed. The notebook can build the frontend image once and Cloud-Run-deploy it with `--set-env-vars=API_BASE=...,NOVNC_URL=...`.

### Agent Engine tools — env-driven URLs

`agent_deploy/tools.py` `trigger_salesforce_opportunity` hardcoded:
- `BACKEND_URL = "https://deal-desk-backend-436293010210.us-central1.run.app"`
- `NOVNC_URL = "http://35.223.98.125:6080/vnc.html?autoconnect=true"`

Both now read from `os.environ`. If `BACKEND_URL` is unset, the function returns a clear error pointing the deployer at the env var to set, rather than failing with a confusing connection error against a stale URL.

### .env.example

Documents the four runtime variables operators need to know about: `API_BASE`, `NOVNC_URL`, `BACKEND_URL`, and (clarified) `A2A_AGENT_URL`.

## Test plan

- [ ] `App.jsx` reads from `window.__APP_CONFIG__` with defaults that work for local `npm run dev`
- [ ] Build the frontend image and run with `-e API_BASE=https://example.com` — confirm `/config.js` reflects it
- [ ] Confirm `agent_deploy/tools.py` returns a clear "BACKEND_URL not set" error when env is missing instead of hitting the stale URL
- [ ] Confirm the four new vars appear in `.env.example` with explanatory comments