### PR TITLE
Add Colab Enterprise deploy notebook for Deal Desk Agent

### DIFF
--- a/03-demos/deal-desk-agent/deploy/agent_engine_deploy.py
+++ b/03-demos/deal-desk-agent/deploy/agent_engine_deploy.py
@@ -9,24 +9,33 @@ import sys
 # Add backend to path so we can import the agent
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
 
-# Set required env vars before importing agent
-os.environ["GOOGLE_CLOUD_PROJECT"] = "cpe-slarbi-nvd-ant-demos"
-os.environ["GOOGLE_CLOUD_LOCATION"] = "us-east5"
-os.environ["PROJECT_ID"] = "cpe-slarbi-nvd-ant-demos"
-os.environ["REGION"] = "us-east5"
-os.environ["BQ_DATASET"] = "deal_desk_agent"
-os.environ["MODEL_PROVIDER"] = "claude"
-os.environ["OPUS_MODEL"] = "claude-opus-4-5@20251101"
-os.environ["SONNET_MODEL"] = "claude-sonnet-4-6@default"
-os.environ["HAIKU_MODEL"] = "claude-haiku-4-5@20251001"
+# All deploy-time configuration is read from the environment.
+# Required: GOOGLE_CLOUD_PROJECT (or PROJECT_ID).
+# Optional: GOOGLE_CLOUD_LOCATION/REGION, BQ_DATASET, OPUS_MODEL, SONNET_MODEL,
+#   HAIKU_MODEL, AGENT_ENGINE_LOCATION, STAGING_BUCKET.
+
+PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("PROJECT_ID")
+if not PROJECT_ID:
+    raise RuntimeError(
+        "Set GOOGLE_CLOUD_PROJECT (or PROJECT_ID) before running this script."
+    )
+
+os.environ.setdefault("GOOGLE_CLOUD_PROJECT", PROJECT_ID)
+os.environ.setdefault("PROJECT_ID", PROJECT_ID)
+os.environ.setdefault("GOOGLE_CLOUD_LOCATION", os.environ.get("REGION", "us-east5"))
+os.environ.setdefault("REGION", os.environ["GOOGLE_CLOUD_LOCATION"])
+os.environ.setdefault("BQ_DATASET", "deal_desk_agent")
+os.environ.setdefault("MODEL_PROVIDER", "claude")
+os.environ.setdefault("OPUS_MODEL", "claude-opus-4-5@20251101")
+os.environ.setdefault("SONNET_MODEL", "claude-sonnet-4-6@default")
+os.environ.setdefault("HAIKU_MODEL", "claude-haiku-4-5@20251001")
 
 import vertexai
 from vertexai import agent_engines
 from agents import deal_desk_pipeline
 
-PROJECT_ID = "cpe-slarbi-nvd-ant-demos"
-LOCATION = "us-central1"
-STAGING_BUCKET = "gs://cpe-slarbi-nvd-ant-demos-agent-staging"
+LOCATION = os.environ.get("AGENT_ENGINE_LOCATION", "us-central1")
+STAGING_BUCKET = os.environ.get("STAGING_BUCKET", f"gs://{PROJECT_ID}-agent-staging")
 
 print("═" * 60)
 print("  Deal Desk Agent — Agent Engine Deployment")
@@ -75,7 +84,10 @@ remote_agent = client.agent_engines.create(
         "staging_bucket": STAGING_BUCKET,
         "display_name": "Deal Desk Agent",
         "description": "FSI Deal Desk pipeline — Claude on Vertex AI + ADK",
-        "service_account": f"deal-desk-agent-sa@{PROJECT_ID}.iam.gserviceaccount.com",
+        "service_account": os.environ.get(
+            "AGENT_SERVICE_ACCOUNT",
+            f"deal-desk-agent-sa@{PROJECT_ID}.iam.gserviceaccount.com",
+        ),
     },
 )
 

--- a/05-solution-accelerators/README.md
+++ b/05-solution-accelerators/README.md
@@ -6,3 +6,4 @@ Pre-packaged, enterprise-ready architectures and automation pipelines to jumpsta
 
 | Accelerator | Description |
 |---|---|
+| [`deal-desk-agent-deploy`](./deal-desk-agent-deploy) | **Colab Enterprise deploy notebook** for the [Deal Desk Agent](../03-demos/deal-desk-agent) demo. Stands up BigQuery + seed data, Cloud Run backend/frontend, GCE browser VM, Agent Engine, and registers with Gemini Enterprise — cell-by-cell from a fresh GCP project in 25-40 min. |

--- a/05-solution-accelerators/deal-desk-agent-deploy/README.md
+++ b/05-solution-accelerators/deal-desk-agent-deploy/README.md
@@ -1,0 +1,36 @@
+# Deal Desk Agent — Colab Enterprise Deploy Accelerator
+
+**Stand up the [Deal Desk Agent demo](../../03-demos/deal-desk-agent) end-to-end in a fresh Google Cloud project, cell-by-cell from a single notebook.**
+
+## What this accelerator does
+
+Running [`colab_deploy.ipynb`](./colab_deploy.ipynb) top-to-bottom in **Colab Enterprise** deploys:
+
+- **BigQuery** dataset + 4 tables, seeded with ~20 synthetic FSI clients
+- **Backend** (FastAPI) on Cloud Run — orchestrates the multi-agent pipeline
+- **Frontend** (React/Vite) on Cloud Run — the demo UI
+- **Browser VM** (n2-standard-4) on Compute Engine — Xvfb + Chrome + noVNC + Salesforce Computer Use agent
+- **Secrets** (`AGENT_SECRET`, Salesforce credentials) in Secret Manager
+- **Agent Engine** deployment of the ADK pipeline — captures the resource ID
+- **Gemini Enterprise** registration — registers the agent into your existing engine using both A2A and the Agent Engine resource
+
+Plus smoke tests and teardown cells.
+
+## Prerequisites
+
+The notebook §1 walks through these in detail. Summary:
+
+1. **GCP project** with billing enabled and the right IAM roles
+2. **Vertex AI Claude model access** for `claude-opus-4-5`, `claude-sonnet-4-6`, `claude-haiku-4-5` in `us-east5`
+3. **Salesforce Developer Edition org** ([sign up](https://developer.salesforce.com/signup))
+4. **Existing Gemini Enterprise engine** (you provide the engine ID)
+5. Operator workstation public IP (for the noVNC firewall rule)
+
+## Time and cost
+
+- **Wall-clock:** ~25-40 min for a fresh deploy (Cloud Build × 3, GCE cold-start, Agent Engine deploy)
+- **Cost:** ~$5-15 for a deploy + ~30 min idle. The GCE browser VM bills 24/7 if left running — **run §20 teardown cells**.
+
+## Disclaimer
+
+The deployed system is a **demonstration**, not production-ready software. See [`03-demos/deal-desk-agent/DESIGN.md`](../../03-demos/deal-desk-agent/DESIGN.md) §9 for known limitations and §10 for the security model. Do not deploy against real client data, production Salesforce orgs, or regulated workloads.

--- a/05-solution-accelerators/deal-desk-agent-deploy/colab_deploy.ipynb
+++ b/05-solution-accelerators/deal-desk-agent-deploy/colab_deploy.ipynb
@@ -1,0 +1,445 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Deal Desk Agent \u2014 Colab Enterprise Deploy\n\n**FSI Deal Desk Pipeline \u2014 Anthropic + Google Cloud: Better Together**\n\nThis notebook stands up the entire Deal Desk Agent system in a fresh Google Cloud project, end-to-end:\n\n1. Enables APIs, creates service accounts, sets IAM\n2. Creates BigQuery dataset + tables, seeds synthetic FSI client data\n3. Builds three container images via Cloud Build (backend, frontend, computer-use VM)\n4. Deploys backend + frontend to Cloud Run, browser VM to Compute Engine\n5. Stores secrets in Secret Manager (`AGENT_SECRET`, Salesforce credentials)\n6. Deploys the ADK agent to Vertex AI Agent Engine \u2014 captures the resource ID\n7. Registers the agent with **Gemini Enterprise** via the Discovery Engine API \u2014 uses the captured Agent Engine ID\n8. Runs smoke tests\n9. Provides teardown cells (last section \u2014 **do not skip if you want to stop billing**)\n\nTotal wall-clock: **25\u201340 minutes**. Most of that is Cloud Build + GCE cold-start + Agent Engine deploy.\n\n---\n\n> ## Disclaimer \u2014 Use At Your Own Risk\n>\n> This notebook deploys a **demonstration** system showcasing the art of the possible with Claude on Vertex AI, Google ADK, and Computer Use. It is **not production-ready** and is **not supported**.\n>\n> The deployed system is single-tenant, drives a Salesforce Developer Edition sandbox, uses in-memory ADK sessions, and ships with the known limitations documented in [`DESIGN.md` \u00a79](../../03-demos/deal-desk-agent/DESIGN.md). Sample BigQuery data is synthetic and does not represent real clients.\n>\n> **Do not deploy this against real client data, production Salesforce orgs, or regulated workloads.** Adapting any part of this for production use requires (at minimum): IAM-based auth in place of the shared-secret pattern, persistent session storage, rate limiting, structured audit logging, secret rotation, network controls (VPC SC), and a full independent security review.\n>\n> Code is provided **as-is, without warranty of any kind**.\n\n---\n\n> ## Cost notice\n>\n> A full deploy + ~30 min of idle costs roughly **$5\u201315** in GCE + Cloud Run + Vertex inference. The GCE browser VM bills 24/7 if left running. **Run the teardown cells at the end of your session.**\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Prerequisites \u2014 read before running any cell\n\nThe notebook can detect and fail-fast on most issues, but four things must be done **before** opening this notebook. Skip any of them and the preflight cell in \u00a73 will stop with an error.\n\n### 1.1 GCP project\n- A GCP project with **billing enabled**\n- You are an Owner or have these roles: `roles/serviceusage.serviceUsageAdmin`, `roles/iam.serviceAccountAdmin`, `roles/run.admin`, `roles/compute.admin`, `roles/artifactregistry.admin`, `roles/bigquery.admin`, `roles/aiplatform.admin`, `roles/secretmanager.admin`, `roles/storage.admin`, `roles/discoveryengine.admin`\n\n### 1.2 Vertex AI Claude model access (most common silent failure)\nFor your project, you must have explicit access to all three Claude models. Console \u2192 **Vertex AI \u2192 Model Garden** \u2192 search \"Claude\" \u2192 for each, click **Enable** and accept Anthropic's commercial terms:\n\n| Model ID | Used for |\n|---|---|\n| `claude-opus-4-5@20251101` | Research + Synthesis agents |\n| `claude-sonnet-4-6@default` | Compliance + Salesforce (Computer Use) agents |\n| `claude-haiku-4-5@20251001` | Risk scoring agent |\n\nRegion: **`us-east5`** (this is the only Claude region in the demo).\n\nIf skipped: every deploy succeeds, every inference returns 403. The preflight cell catches this.\n\n### 1.3 Salesforce Developer Edition org\n\nThe browser VM container reads only `SALESFORCE_URL` \u2014 login is human-in-the-loop the first time you open noVNC, then Computer Use takes over. You need a fresh DE org.\n\n1. Go to **https://developer.salesforce.com/signup**\n2. Fill the form. Two field gotchas:\n   - **Email** \u2014 must be one you can receive at; you'll click a verification link\n   - **Username** \u2014 must be in *email format* (e.g., `dealdesk.demo@example.com`), but does NOT have to be a real address. It's just the login string. Pick something globally unique across all of Salesforce.\n3. Submit \u2192 check email \u2192 click the verification link \u2192 set your password\n4. After login you'll land at a URL like `https://orgfarm-XXXXXXXXXX-dev-ed.develop.lightning.force.com/lightning/page/home`. **Copy the host portion only** (everything before `/lightning/`) \u2014 that's your `SALESFORCE_URL` for \u00a79.2.\n5. **Do NOT enable MFA** on this dev org. If you accidentally enabled it, the Computer Use agent will get stuck on the verification step. Disable under Setup \u2192 Identity Verification.\n6. **Do NOT** create a security token or Connected App \u2014 this demo uses interactive UI login via Computer Use, not API auth.\n\nYou will paste the URL, username (the email-format login string), and password into the cell in \u00a79.2. They go into Secret Manager \u2014 never written to the notebook source.\n\n### 1.4 Existing Gemini Enterprise engine\n\nYou need an existing **Gemini Enterprise / Agentspace engine** to register the deployed agent into. To find your engine ID:\n- Console \u2192 **Gemini Enterprise \u2192 Apps** \u2192 click your app \u2192 the **App ID** (also called Engine ID) is shown in the URL: `.../engines/{ENGINE_ID}/...`\n- Note it down for cell 18.1\n\nIf you don't have an engine yet, create one first via **Gemini Enterprise \u2192 Apps \u2192 Create App \u2192 Search**. The notebook does NOT create the engine for you (creating one provisions billable resources and is a deliberate decision).\n\n### 1.5 Operator workstation\n- A modern browser to open the noVNC URL and the deployed frontend\n- Your **public IP** \u2014 the noVNC firewall rule restricts to your IP only. The notebook auto-detects via `curl ifconfig.me` and lets you override before creating the rule.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Configuration\n\nSet everything you'll need in this single cell. Every later cell reads from these variables.\n\nIf you re-run the notebook later (after a partial failure or to update a single resource), only this cell and the preflight cell need to be re-run before jumping to the section you want."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\nimport subprocess\nimport json\n\n# \u2500\u2500\u2500 REQUIRED \u2014 change these \u2500\u2500\u2500\nPROJECT_ID = \"your-gcp-project-id\"            # e.g., \"my-deal-desk-demo\"\nGEMINI_ENTERPRISE_ENGINE_ID = \"your-engine-id\"  # from Console \u2192 Gemini Enterprise \u2192 Apps\n\n# \u2500\u2500\u2500 Regions (pinned \u2014 do not change unless you know why) \u2500\u2500\u2500\nMODEL_REGION = \"us-east5\"      # Vertex AI Claude region (only region in demo)\nINFRA_REGION = \"us-central1\"   # Cloud Run + GCE + Artifact Registry\nBQ_LOCATION  = \"US\"            # BigQuery multi-region\nAGENT_ENGINE_LOCATION = \"us-central1\"\nDISCOVERY_ENGINE_LOCATION = \"global\"  # Gemini Enterprise engines live in 'global' or 'eu'\n\n# \u2500\u2500\u2500 Resource names (sane defaults \u2014 change if they collide with existing) \u2500\u2500\u2500\nARTIFACT_REPO   = \"deal-desk-agent\"\nSERVICE_ACCOUNT = \"deal-desk-agent-sa\"\nBACKEND_SERVICE  = \"deal-desk-backend\"\nFRONTEND_SERVICE = \"deal-desk-frontend\"\nGCE_INSTANCE     = \"deal-desk-browser\"\nGCE_STATIC_IP    = \"deal-desk-browser-ip\"\nGCE_ZONE         = f\"{INFRA_REGION}-a\"\nGCE_MACHINE_TYPE = \"n2-standard-4\"      # upgraded from e2-standard-4 for Chrome+CU loop\nBQ_DATASET = \"deal_desk_agent\"\n\n# \u2500\u2500\u2500 Model IDs (pinned to what the agent code expects) \u2500\u2500\u2500\nOPUS_MODEL   = \"claude-opus-4-5@20251101\"\nSONNET_MODEL = \"claude-sonnet-4-6@default\"\nHAIKU_MODEL  = \"claude-haiku-4-5@20251001\"\n\n# \u2500\u2500\u2500 Secret names in Secret Manager \u2500\u2500\u2500\nSECRET_AGENT      = \"deal-desk-agent-secret\"\nSECRET_SF_URL     = \"deal-desk-salesforce-url\"\nSECRET_SF_USER    = \"deal-desk-salesforce-username\"\nSECRET_SF_PASS    = \"deal-desk-salesforce-password\"\n\n# \u2500\u2500\u2500 Operator public IP (for noVNC firewall) \u2014 auto-detected, override below if needed \u2500\u2500\u2500\ntry:\n    OPERATOR_PUBLIC_IP = subprocess.check_output(\n        [\"curl\", \"-s\", \"--max-time\", \"5\", \"https://ifconfig.me\"]\n    ).decode().strip()\nexcept Exception:\n    OPERATOR_PUBLIC_IP = \"\"\n\n# Manual override \u2014 uncomment and set if auto-detection wrong (e.g., behind VPN, shared egress)\n# OPERATOR_PUBLIC_IP = \"203.0.113.42\"\n\n# \u2500\u2500\u2500 Derived / computed (do not edit) \u2500\u2500\u2500\nSA_EMAIL = f\"{SERVICE_ACCOUNT}@{PROJECT_ID}.iam.gserviceaccount.com\"\nAR_PREFIX = f\"{INFRA_REGION}-docker.pkg.dev/{PROJECT_ID}/{ARTIFACT_REPO}\"\nBACKEND_IMAGE  = f\"{AR_PREFIX}/backend:latest\"\nFRONTEND_IMAGE = f\"{AR_PREFIX}/frontend:latest\"\nBROWSER_IMAGE  = f\"{AR_PREFIX}/browser-vm:latest\"\nSTAGING_BUCKET = f\"gs://{PROJECT_ID}-agent-staging\"\n\n# Validate required values are set\nassert PROJECT_ID and PROJECT_ID != \"your-gcp-project-id\", \"Set PROJECT_ID before running.\"\nassert GEMINI_ENTERPRISE_ENGINE_ID and GEMINI_ENTERPRISE_ENGINE_ID != \"your-engine-id\", \\\n    \"Set GEMINI_ENTERPRISE_ENGINE_ID before running. See \u00a71.4 for how to find it.\"\nassert OPERATOR_PUBLIC_IP, \"Could not auto-detect public IP. Set OPERATOR_PUBLIC_IP manually.\"\n\n# Export to environment so subprocess gcloud calls inherit\nos.environ[\"PROJECT_ID\"] = PROJECT_ID\nos.environ[\"CLOUDSDK_CORE_PROJECT\"] = PROJECT_ID\n\nprint(\"Configuration loaded.\")\nprint(f\"  Project:           {PROJECT_ID}\")\nprint(f\"  Gemini Engine ID:  {GEMINI_ENTERPRISE_ENGINE_ID}\")\nprint(f\"  Model region:      {MODEL_REGION}\")\nprint(f\"  Infra region:      {INFRA_REGION}\")\nprint(f\"  Operator IP:       {OPERATOR_PUBLIC_IP}\")\nprint(f\"  Service account:   {SA_EMAIL}\")\nprint(f\"  Staging bucket:    {STAGING_BUCKET}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Preflight checks \u2014 fail fast before any deploy\n\nThis cell makes ~7 quick checks against the configured project. If any fail, it stops with a clear error and a remediation hint. Do not skip \u2014 the most common deploy failure is missing Vertex Claude model access, which produces silent 403s much later in the flow."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import shlex\nimport urllib.request\n\ndef sh(cmd, capture=True, check=True):\n    \"\"\"Run a shell command and return stdout.\"\"\"\n    if isinstance(cmd, str):\n        cmd = shlex.split(cmd)\n    result = subprocess.run(cmd, capture_output=capture, text=True)\n    if check and result.returncode != 0:\n        raise RuntimeError(f\"Command failed: {' '.join(cmd)}\\n{result.stderr}\")\n    return result.stdout.strip()\n\nprint(\"Running preflight checks...\\n\")\n\n# 1. gcloud is configured to the right project\ncurrent = sh(f\"gcloud config get-value project\")\nif current != PROJECT_ID:\n    print(f\"  Setting gcloud project to {PROJECT_ID}\")\n    sh(f\"gcloud config set project {PROJECT_ID}\")\nprint(f\"  [OK] gcloud project = {PROJECT_ID}\")\n\n# 2. Billing is enabled\nbilling = sh(f\"gcloud billing projects describe {PROJECT_ID} --format=value(billingEnabled)\", check=False)\nassert billing == \"True\", (\n    f\"Billing not enabled on project {PROJECT_ID}. \"\n    f\"Enable at https://console.cloud.google.com/billing/linkedaccount?project={PROJECT_ID}\"\n)\nprint(f\"  [OK] Billing enabled\")\n\n# 3. ADC works\nimport google.auth\ntry:\n    creds, _ = google.auth.default()\n    print(f\"  [OK] Application Default Credentials available\")\nexcept Exception as e:\n    raise RuntimeError(\n        \"ADC not configured. In Colab Enterprise this is normally automatic; \"\n        \"if running locally run: gcloud auth application-default login\"\n    ) from e\n\n# 4. Vertex AI Claude model access \u2014 try a 1-token rawPredict for each model\nimport google.auth.transport.requests\ncreds.refresh(google.auth.transport.requests.Request())\ntoken = creds.token\n\nfor model in [OPUS_MODEL, SONNET_MODEL, HAIKU_MODEL]:\n    url = (\n        f\"https://{MODEL_REGION}-aiplatform.googleapis.com/v1/\"\n        f\"projects/{PROJECT_ID}/locations/{MODEL_REGION}/\"\n        f\"publishers/anthropic/models/{model}:rawPredict\"\n    )\n    body = json.dumps({\n        \"anthropic_version\": \"vertex-2023-10-16\",\n        \"max_tokens\": 1,\n        \"messages\": [{\"role\": \"user\", \"content\": \"hi\"}],\n    }).encode()\n    req = urllib.request.Request(\n        url, data=body,\n        headers={\"Authorization\": f\"Bearer {token}\", \"Content-Type\": \"application/json\"},\n        method=\"POST\",\n    )\n    try:\n        with urllib.request.urlopen(req, timeout=15) as resp:\n            assert resp.status == 200\n        print(f\"  [OK] Vertex Claude {model} reachable\")\n    except urllib.error.HTTPError as e:\n        body = e.read().decode(\"utf-8\", errors=\"replace\")\n        raise RuntimeError(\n            f\"Vertex Claude {model} returned HTTP {e.code}.\\n\"\n            f\"Response: {body[:500]}\\n\"\n            f\"Most likely cause: model not enabled for this project. \"\n            f\"Enable at https://console.cloud.google.com/vertex-ai/model-garden?project={PROJECT_ID} \"\n            f\"(search 'Claude', click each model, Enable, accept terms).\"\n        ) from None\n\n# 5. Operator IP is a sane IPv4\nimport ipaddress\ntry:\n    ipaddress.IPv4Address(OPERATOR_PUBLIC_IP)\n    print(f\"  [OK] Operator public IP = {OPERATOR_PUBLIC_IP}\")\nexcept ValueError:\n    raise RuntimeError(\n        f\"OPERATOR_PUBLIC_IP={OPERATOR_PUBLIC_IP!r} is not a valid IPv4. \"\n        f\"Set it manually in \u00a72.\"\n    )\n\n# 6. Discoveryengine API reachable (we'll enable it next, just check the project exists for it)\nprint(f\"  [OK] All preflight checks passed.\\n\")\nprint(\"Ready to deploy. Continue to \u00a74.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Enable APIs\n\nEnables every API the deploy needs. Idempotent \u2014 safe to re-run."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "APIS = [\n    \"aiplatform.googleapis.com\",\n    \"bigquery.googleapis.com\",\n    \"run.googleapis.com\",\n    \"cloudbuild.googleapis.com\",\n    \"artifactregistry.googleapis.com\",\n    \"compute.googleapis.com\",\n    \"secretmanager.googleapis.com\",\n    \"iamcredentials.googleapis.com\",\n    \"discoveryengine.googleapis.com\",\n    \"storage.googleapis.com\",\n    \"cloudresourcemanager.googleapis.com\",\n]\n\nprint(f\"Enabling {len(APIS)} APIs (this can take 1-2 minutes)...\")\nsh(f\"gcloud services enable {' '.join(APIS)} --project={PROJECT_ID}\")\nprint(\"All APIs enabled.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Install pinned Python tooling\n\nPinned versions matching `backend/requirements.txt` and `agent_deploy/requirements.txt` from the repo, so the Agent Engine deploy and the inline checks behave the same as the deployed services."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "%pip install -q --upgrade \\\n    \"google-cloud-aiplatform[agent_engines,adk]>=1.78.0\" \\\n    \"google-adk>=1.2.0\" \\\n    \"anthropic[vertex]>=0.43.0\" \\\n    \"google-cloud-bigquery>=3.27.0\" \\\n    \"google-cloud-secret-manager>=2.20.0\" \\\n    \"google-cloud-discoveryengine>=0.13.0\" \\\n    \"google-cloud-storage>=2.18.0\" \\\n    \"httpx>=0.27.0\" \\\n    \"cloudpickle>=3.0.0\" \\\n    \"pydantic>=2.0.0\"\n\nprint(\"\\nIMPORTANT: if Colab prompted to RESTART the runtime, restart now then re-run \u00a72 + \u00a73 + \u00a75.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 6. Clone the demo repo\n\nPulls the Deal Desk source from the partner repo. The Agent Engine deploy and Cloud Build cells reference these files directly."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "REPO_URL = \"https://github.com/PTA-Co-innovation-Team/Anthropic-Google-Co-Innovation.git\"\nWORKDIR = \"/content/anthropic-google-coinnov\"\nDEMO_DIR = f\"{WORKDIR}/03-demos/deal-desk-agent\"\n\nif not os.path.isdir(WORKDIR):\n    sh(f\"git clone --depth 1 {REPO_URL} {WORKDIR}\")\nelse:\n    print(f\"Repo already cloned at {WORKDIR} \u2014 pulling latest\")\n    sh(f\"git -C {WORKDIR} pull --ff-only\")\n\nassert os.path.isdir(DEMO_DIR), f\"Expected demo at {DEMO_DIR} \u2014 did the repo structure change?\"\nprint(f\"\\nDemo source ready at: {DEMO_DIR}\")\nprint(\"Tree:\")\nsh(f\"ls -la {DEMO_DIR}\", capture=False)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 7. BigQuery \u2014 dataset, schemas, and synthetic seed data\n\nThe agent reads from four tables. Schemas are derived from `backend/tools/bigquery_tools.py` (every read tool dictates what columns it expects).\n\nThe repo ships **no seed data**. This section seeds ~20 synthetic FSI clients (pension funds, family offices, RIAs, hedge funds) with matching market intel and compliance records. Names are fictional. Numbers are realistic but invented.\n\n### 7.1 Create dataset"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from google.cloud import bigquery\n\nbq = bigquery.Client(project=PROJECT_ID)\ndataset_ref = f\"{PROJECT_ID}.{BQ_DATASET}\"\n\ndataset = bigquery.Dataset(dataset_ref)\ndataset.location = BQ_LOCATION\ntry:\n    dataset = bq.create_dataset(dataset, exists_ok=True)\n    print(f\"Dataset ready: {dataset_ref} ({BQ_LOCATION})\")\nexcept Exception as e:\n    raise RuntimeError(f\"Failed to create dataset {dataset_ref}: {e}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 7.2 Create tables\n\nSchemas match what `query_client_data`, `query_market_intelligence`, `query_compliance_records`, and `insert_deal_package` expect."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "SCHEMAS = {\n    \"clients\": [\n        bigquery.SchemaField(\"name\", \"STRING\", mode=\"REQUIRED\"),\n        bigquery.SchemaField(\"aum_millions\", \"FLOAT64\", mode=\"REQUIRED\"),\n        bigquery.SchemaField(\"strategy\", \"STRING\"),\n        bigquery.SchemaField(\"mandate_type\", \"STRING\"),\n        bigquery.SchemaField(\"fee_structure\", \"STRING\"),\n        bigquery.SchemaField(\"primary_contact\", \"STRING\"),\n        bigquery.SchemaField(\"primary_contact_title\", \"STRING\"),\n        bigquery.SchemaField(\"primary_contact_email\", \"STRING\"),\n        bigquery.SchemaField(\"relationship_status\", \"STRING\"),\n        bigquery.SchemaField(\"domicile\", \"STRING\"),\n        bigquery.SchemaField(\"founded_year\", \"INT64\"),\n        bigquery.SchemaField(\"client_type\", \"STRING\"),\n    ],\n    \"market_intelligence\": [\n        bigquery.SchemaField(\"client_name\", \"STRING\", mode=\"REQUIRED\"),\n        bigquery.SchemaField(\"date\", \"DATE\", mode=\"REQUIRED\"),\n        bigquery.SchemaField(\"record_type\", \"STRING\"),  # SEC_FILING | NEWS | MARKET_DATA\n        bigquery.SchemaField(\"title\", \"STRING\"),\n        bigquery.SchemaField(\"source\", \"STRING\"),\n        bigquery.SchemaField(\"summary\", \"STRING\"),\n        bigquery.SchemaField(\"relevance_score\", \"FLOAT64\"),\n    ],\n    \"compliance_records\": [\n        bigquery.SchemaField(\"client_name\", \"STRING\", mode=\"REQUIRED\"),\n        bigquery.SchemaField(\"kyc_status\", \"STRING\"),       # PASSED | PENDING | FAILED\n        bigquery.SchemaField(\"aml_status\", \"STRING\"),\n        bigquery.SchemaField(\"sanctions_status\", \"STRING\"), # CLEAR | HIT | REVIEW\n        bigquery.SchemaField(\"finra_status\", \"STRING\"),     # REGISTERED | NOT_REQUIRED | PENDING\n        bigquery.SchemaField(\"risk_tier\", \"STRING\"),        # LOW | MEDIUM | HIGH\n        bigquery.SchemaField(\"last_review_date\", \"DATE\"),\n        bigquery.SchemaField(\"notes\", \"STRING\"),\n    ],\n    \"deal_packages\": [\n        bigquery.SchemaField(\"deal_id\", \"STRING\", mode=\"REQUIRED\"),\n        bigquery.SchemaField(\"client_name\", \"STRING\", mode=\"REQUIRED\"),\n        bigquery.SchemaField(\"aum_millions\", \"FLOAT64\"),\n        bigquery.SchemaField(\"strategy\", \"STRING\"),\n        bigquery.SchemaField(\"mandate_type\", \"STRING\"),\n        bigquery.SchemaField(\"fee_structure\", \"STRING\"),\n        bigquery.SchemaField(\"compliance_status\", \"STRING\"),\n        bigquery.SchemaField(\"risk_tier\", \"STRING\"),\n        bigquery.SchemaField(\"risk_score\", \"FLOAT64\"),\n        bigquery.SchemaField(\"primary_contact\", \"STRING\"),\n        bigquery.SchemaField(\"primary_contact_title\", \"STRING\"),\n        bigquery.SchemaField(\"salesforce_opportunity_id\", \"STRING\"),\n        bigquery.SchemaField(\"status\", \"STRING\"),\n        bigquery.SchemaField(\"created_by\", \"STRING\"),\n        bigquery.SchemaField(\"created_at\", \"TIMESTAMP\"),\n        bigquery.SchemaField(\"notes\", \"STRING\"),\n    ],\n}\n\nfor table_name, schema in SCHEMAS.items():\n    table_ref = f\"{dataset_ref}.{table_name}\"\n    table = bigquery.Table(table_ref, schema=schema)\n    bq.create_table(table, exists_ok=True)\n    print(f\"  Table ready: {table_name}\")\nprint(\"\\nAll 4 tables created.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 7.3 Seed synthetic data\n\n20 fictional FSI clients spanning hedge funds, pension funds, family offices, and RIAs. Each has matching market intelligence (SEC filings, news) and compliance records. Deterministic \u2014 re-running this cell against an empty table produces the same data.\n\nIf the tables already have data from a previous run, this cell **truncates and reloads** to keep things deterministic."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from datetime import date, timedelta\nimport random\n\n# Deterministic seed so re-runs produce identical data\nrandom.seed(42)\n\nCLIENTS = [\n    # (name, aum_millions, strategy, mandate_type, fee_structure, contact, title, email, status, domicile, founded, client_type)\n    (\"Beacon Hedge Fund\",            500.0, \"Global Macro\",            \"Discretionary\",      \"2/20\",     \"Marcus Webb\",      \"CIO\",              \"mwebb@beaconhf.com\",       \"Active\",    \"Cayman Islands\", 2008, \"Hedge Fund\"),\n    (\"ACME Capital Management\",      250.0, \"Long/Short Equity\",       \"Institutional\",      \"2/20\",     \"Sarah Chen\",       \"CIO\",              \"schen@acmecap.com\",        \"Prospect\",  \"Delaware\",       2014, \"Hedge Fund\"),\n    (\"Meridian Partners\",            180.0, \"Multi-Strategy\",          \"Separately Managed\", \"1.5/15\",   \"James Holloway\",   \"Managing Partner\", \"jholloway@meridian.com\",   \"Returning\", \"Connecticut\",    2011, \"Hedge Fund\"),\n    (\"Cascade Pension Trust\",       4200.0, \"Liability-Driven\",        \"Institutional\",      \"0.35 flat\",\"Diane Park\",       \"Treasurer\",        \"dpark@cascadepension.org\", \"Active\",    \"Oregon\",         1984, \"Pension Fund\"),\n    (\"Northstar Endowment\",         2800.0, \"60/40 Balanced\",          \"Institutional\",      \"0.40 flat\",\"Robert Kim\",       \"CIO\",              \"rkim@northstar.edu\",       \"Active\",    \"Massachusetts\",  1962, \"Endowment\"),\n    (\"Hartwell Family Office\",       320.0, \"Multi-Asset\",             \"Wealth Management\",  \"1.0 flat\", \"Eleanor Hartwell\", \"Principal\",        \"ehartwell@hartwellfo.com\", \"Returning\", \"New York\",       1998, \"Family Office\"),\n    (\"Apex Quantitative\",            850.0, \"Statistical Arbitrage\",   \"Discretionary\",      \"2/30\",     \"Vikram Rao\",       \"Head of Research\", \"vrao@apexquant.com\",       \"Active\",    \"Delaware\",       2016, \"Hedge Fund\"),\n    (\"Greylock Wealth Advisors\",     145.0, \"Tax-Aware Equity\",        \"Wealth Management\",  \"0.85 flat\",\"Patricia Mendez\",  \"Managing Director\",\"pmendez@greylockwa.com\",   \"Active\",    \"California\",     2009, \"RIA\"),\n    (\"Summit Insurance Holdings\",   3500.0, \"Investment Grade Credit\", \"Institutional\",      \"0.30 flat\",\"Hideki Tanaka\",    \"CIO\",              \"htanaka@summitins.com\",    \"Active\",    \"Bermuda\",        1995, \"Insurance\"),\n    (\"Larkspur Venture Partners\",    220.0, \"Late-Stage Venture\",      \"Limited Partnership\",\"2/25\",     \"Alice Donovan\",    \"General Partner\",  \"adonovan@larkspurvp.com\",  \"Prospect\",  \"Delaware\",       2019, \"VC Fund\"),\n    (\"Whitestone Macro Fund\",        680.0, \"Discretionary Macro\",     \"Discretionary\",      \"1.75/20\",  \"Niall O'Connor\",   \"Founder\",          \"noconnor@whitestone.com\",  \"Returning\", \"Cayman Islands\", 2013, \"Hedge Fund\"),\n    (\"Cordillera Mining Pension\",   1900.0, \"Real Assets Tilt\",        \"Institutional\",      \"0.45 flat\",\"Maria Aguilar\",    \"Investment Officer\",\"maguilar@cordmining.org\", \"Active\",    \"Colorado\",       1976, \"Pension Fund\"),\n    (\"Bristol Sovereign Capital\",   8500.0, \"Sovereign Wealth\",        \"Institutional\",      \"0.20 flat\",\"Khalid Al-Rashid\", \"Director, Public Markets\",\"kalrashid@bristolsc.gov\",\"Active\",\"Singapore\",      2007, \"Sovereign Wealth\"),\n    (\"Driftwood Asset Mgmt\",         410.0, \"Long-Only Equity\",        \"Mutual Fund Sub-Advisor\",\"0.65 flat\",\"Henrik Olsen\", \"Lead PM\",          \"holsen@driftwoodam.com\",   \"Returning\", \"Minnesota\",      2003, \"Asset Manager\"),\n    (\"Provident Healthcare Trust\",  1200.0, \"ESG-Tilted Balanced\",     \"Institutional\",      \"0.50 flat\",\"Sandra Whittaker\", \"CIO\",              \"swhittaker@providenthc.org\",\"Active\",\"Pennsylvania\",   1989, \"Healthcare System\"),\n    (\"Riverbend Credit Opportunities\",560.0, \"Distressed Credit\",      \"Closed-End Fund\",    \"1.5/20\",   \"Tomas Rivera\",     \"Portfolio Manager\",\"trivera@riverbendco.com\",  \"Active\",    \"Cayman Islands\", 2012, \"Credit Fund\"),\n    (\"Sentinel Multi-Family Office\", 290.0, \"Customized Multi-Asset\",  \"Wealth Management\",  \"0.95 flat\",\"Hannah Goldberg\",  \"Lead Advisor\",     \"hgoldberg@sentinelmfo.com\",\"Returning\", \"Illinois\",       2006, \"Family Office\"),\n    (\"Cobalt Energy Partners\",       780.0, \"Energy Infrastructure\",   \"Limited Partnership\",\"2/20\",     \"Wesley Carrington\",\"Operating Partner\",\"wcarrington@cobaltenergy.com\",\"Prospect\",\"Texas\",         2015, \"Private Equity\"),\n    (\"Olympia Foundation\",           640.0, \"Endowment Style\",         \"Institutional\",      \"0.42 flat\",\"Frances Liang\",    \"Director of Investments\",\"fliang@olympiafdn.org\", \"Active\",  \"Washington\",     1971, \"Foundation\"),\n    (\"Tidewater RIA Group\",           95.0, \"Core/Satellite\",          \"Wealth Management\",  \"0.75 flat\",\"David Pham\",       \"Founder\",          \"dpham@tidewaterria.com\",   \"Returning\", \"Virginia\",       2017, \"RIA\"),\n]\n\n# Truncate then load (idempotent)\nprint(\"Loading clients table...\")\nsh(f\"bq query --project_id={PROJECT_ID} --use_legacy_sql=false 'TRUNCATE TABLE `{PROJECT_ID}.{BQ_DATASET}.clients`'\", check=False)\n\nrows = [\n    {\n        \"name\": c[0], \"aum_millions\": c[1], \"strategy\": c[2], \"mandate_type\": c[3],\n        \"fee_structure\": c[4], \"primary_contact\": c[5], \"primary_contact_title\": c[6],\n        \"primary_contact_email\": c[7], \"relationship_status\": c[8],\n        \"domicile\": c[9], \"founded_year\": c[10], \"client_type\": c[11],\n    }\n    for c in CLIENTS\n]\nerrors = bq.insert_rows_json(f\"{dataset_ref}.clients\", rows)\nassert not errors, f\"Failed to insert clients: {errors}\"\nprint(f\"  Inserted {len(rows)} client rows\")\n\n# Market intelligence \u2014 1-3 records per client\nprint(\"\\nLoading market_intelligence table...\")\nsh(f\"bq query --project_id={PROJECT_ID} --use_legacy_sql=false 'TRUNCATE TABLE `{PROJECT_ID}.{BQ_DATASET}.market_intelligence`'\", check=False)\n\nINTEL_TEMPLATES = {\n    \"SEC_FILING\": [\n        (\"Form ADV Part 2A annual update\", \"SEC EDGAR\", \"Annual brochure update; AUM and strategy disclosures consistent with prior year.\"),\n        (\"Form 13F Q3 holdings disclosure\", \"SEC EDGAR\", \"Reportable positions filed; concentration in financials and tech sectors.\"),\n        (\"Form D \u2014 exempt offering\", \"SEC EDGAR\", \"Notice of new private fund launch under Reg D 506(c).\"),\n    ],\n    \"NEWS\": [\n        (\"Quarterly letter to investors\", \"Pitchbook\", \"Returns in line with peer median; manager attributes outperformance to defensive positioning.\"),\n        (\"Senior hire announcement\", \"Bloomberg\", \"Hired new head of risk from a tier-1 bank; signals institutional process maturation.\"),\n        (\"Strategy expansion into private credit\", \"Reuters\", \"Plans to launch a sleeve dedicated to direct lending in 2026.\"),\n        (\"Closed Series III fund at hard cap\", \"WSJ\", \"Oversubscribed close at $750M hard cap; LPs include public pensions.\"),\n    ],\n    \"MARKET_DATA\": [\n        (\"Trailing 12mo Sharpe ratio\", \"Internal estimate\", \"Sharpe ~1.2 vs peer median 0.9; volatility within mandate band.\"),\n        (\"Drawdown vs benchmark\", \"Bloomberg\", \"Max drawdown 8.4% in last 24 months vs benchmark 11.2%.\"),\n    ],\n}\n\nintel_rows = []\ntoday = date.today()\nfor c in CLIENTS:\n    name = c[0]\n    n_records = random.randint(1, 3)\n    for i in range(n_records):\n        record_type = random.choice(list(INTEL_TEMPLATES.keys()))\n        tmpl = random.choice(INTEL_TEMPLATES[record_type])\n        days_ago = random.randint(7, 180)\n        intel_rows.append({\n            \"client_name\": name,\n            \"date\": (today - timedelta(days=days_ago)).isoformat(),\n            \"record_type\": record_type,\n            \"title\": tmpl[0],\n            \"source\": tmpl[1],\n            \"summary\": tmpl[2],\n            \"relevance_score\": round(random.uniform(0.55, 0.98), 2),\n        })\n\nerrors = bq.insert_rows_json(f\"{dataset_ref}.market_intelligence\", intel_rows)\nassert not errors, f\"Failed to insert market_intelligence: {errors}\"\nprint(f\"  Inserted {len(intel_rows)} market intelligence rows\")\n\n# Compliance \u2014 one record per client; bias most to PASSED with a few REVIEW/PENDING\nprint(\"\\nLoading compliance_records table...\")\nsh(f\"bq query --project_id={PROJECT_ID} --use_legacy_sql=false 'TRUNCATE TABLE `{PROJECT_ID}.{BQ_DATASET}.compliance_records`'\", check=False)\n\ndef _comp_status(client_type, idx):\n    # Most clients are clean; sprinkle a handful of REVIEW/PENDING for demo realism\n    if idx in (1, 9, 17):  # ACME (prospect), Larkspur, Cobalt\n        return (\"PENDING\", \"PENDING\", \"REVIEW\", \"PENDING\", \"MEDIUM\", \"Awaiting completed KYC packet from client; sanctions hit on unrelated namesake \u2014 manual review in progress.\")\n    if idx == 4:  # Northstar \u2014 endowment, large; clean but elevated risk tier from concentration\n        return (\"PASSED\", \"PASSED\", \"CLEAR\", \"NOT_REQUIRED\", \"MEDIUM\", \"Concentration risk in single-manager allocations; periodic IC review.\")\n    if client_type in (\"Sovereign Wealth\", \"Pension Fund\", \"Insurance\", \"Foundation\", \"Endowment\"):\n        return (\"PASSED\", \"PASSED\", \"CLEAR\", \"NOT_REQUIRED\", \"LOW\", \"Institutional client; standard institutional onboarding completed.\")\n    return (\"PASSED\", \"PASSED\", \"CLEAR\", \"REGISTERED\", random.choice([\"LOW\", \"MEDIUM\"]), \"Standard FINRA-registered intermediary; routine annual review.\")\n\ncomp_rows = []\nfor idx, c in enumerate(CLIENTS):\n    name, _, _, _, _, _, _, _, _, _, _, ctype = c\n    kyc, aml, sanc, finra, risk, notes = _comp_status(ctype, idx)\n    comp_rows.append({\n        \"client_name\": name,\n        \"kyc_status\": kyc,\n        \"aml_status\": aml,\n        \"sanctions_status\": sanc,\n        \"finra_status\": finra,\n        \"risk_tier\": risk,\n        \"last_review_date\": (today - timedelta(days=random.randint(15, 200))).isoformat(),\n        \"notes\": notes,\n    })\nerrors = bq.insert_rows_json(f\"{dataset_ref}.compliance_records\", comp_rows)\nassert not errors, f\"Failed to insert compliance_records: {errors}\"\nprint(f\"  Inserted {len(comp_rows)} compliance rows\")\n\n# deal_packages stays empty \u2014 populated by the agent at runtime\nprint(\"\\nSeed complete:\")\ncounts = list(bq.query(f\"\"\"\n    SELECT 'clients' AS t, COUNT(*) AS n FROM `{dataset_ref}.clients`\n    UNION ALL SELECT 'market_intelligence', COUNT(*) FROM `{dataset_ref}.market_intelligence`\n    UNION ALL SELECT 'compliance_records', COUNT(*) FROM `{dataset_ref}.compliance_records`\n    UNION ALL SELECT 'deal_packages', COUNT(*) FROM `{dataset_ref}.deal_packages`\n\"\"\").result())\nfor r in counts:\n    print(f\"  {r.t:25s} {r.n:>5d} rows\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 8. Service account + IAM\n\nSingle service account used by Cloud Run (backend), GCE (browser VM), and Agent Engine. Bound to the minimum roles needed."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Create SA (idempotent)\nexisting = sh(f\"gcloud iam service-accounts list --filter=email:{SA_EMAIL} --format=value(email)\", check=False)\nif existing != SA_EMAIL:\n    sh(f\"gcloud iam service-accounts create {SERVICE_ACCOUNT} \"\n       f\"--display-name='Deal Desk Agent SA' --project={PROJECT_ID}\")\n    print(f\"  Created service account: {SA_EMAIL}\")\nelse:\n    print(f\"  Service account already exists: {SA_EMAIL}\")\n\nROLES = [\n    \"roles/aiplatform.user\",\n    \"roles/bigquery.dataEditor\",\n    \"roles/bigquery.jobUser\",\n    \"roles/secretmanager.secretAccessor\",\n    \"roles/storage.objectViewer\",\n    \"roles/storage.objectCreator\",  # for Agent Engine staging bucket\n    \"roles/logging.logWriter\",\n    \"roles/monitoring.metricWriter\",\n]\n\nprint(f\"\\nBinding {len(ROLES)} roles...\")\nfor role in ROLES:\n    sh(f\"gcloud projects add-iam-policy-binding {PROJECT_ID} \"\n       f\"--member=serviceAccount:{SA_EMAIL} --role={role} --condition=None --quiet\",\n       check=False)\nprint(\"IAM bindings applied.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 9. Secrets \u2014 Secret Manager\n\n### 9.1 Generate AGENT_SECRET\n\nThe shared secret authenticating Cloud Run backend \u2192 GCE browser VM. 32 hex bytes. Generated here, stored in Secret Manager, and read by both the backend and the VM at deploy time."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import secrets as _secrets\n\ndef upsert_secret(name: str, value: str):\n    \"\"\"Create or update a secret in Secret Manager.\"\"\"\n    # Create the secret container (if missing)\n    sh(f\"gcloud secrets describe {name} --project={PROJECT_ID}\", check=False)\n    exists = sh(f\"gcloud secrets list --filter=name~{name}$ --format=value(name) --project={PROJECT_ID}\", check=False)\n    if name not in exists:\n        sh(f\"gcloud secrets create {name} --replication-policy=automatic --project={PROJECT_ID}\")\n        print(f\"  Created secret: {name}\")\n    # Add a new version with the provided value\n    p = subprocess.run(\n        [\"gcloud\", \"secrets\", \"versions\", \"add\", name,\n         f\"--project={PROJECT_ID}\", \"--data-file=-\"],\n        input=value, text=True, capture_output=True, check=True,\n    )\n    print(f\"  Added version to {name}\")\n\nAGENT_SECRET_VALUE = _secrets.token_hex(32)\nupsert_secret(SECRET_AGENT, AGENT_SECRET_VALUE)\nprint(\"\\nAGENT_SECRET stored. The plaintext value is held only in this notebook variable for the rest of the deploy.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 9.2 Salesforce credentials\n\nPaste the URL, username, and password from the DE org you signed up for in \u00a71.3.\n\nThe password input uses `getpass` so it is NOT echoed to the notebook. Once stored in Secret Manager you can clear the cell output if you want."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from getpass import getpass\n\nprint(\"Paste your Salesforce Developer Edition details (from \u00a71.3):\\n\")\nSF_URL  = input(\"SALESFORCE_URL (e.g., https://orgfarm-XXX-dev-ed.develop.lightning.force.com): \").strip()\nSF_USER = input(\"Salesforce username (the email-format login): \").strip()\nSF_PASS = getpass(\"Salesforce password: \")\n\nassert SF_URL.startswith(\"https://\") and \"lightning.force.com\" in SF_URL, \\\n    \"URL should look like https://orgfarm-XXX-dev-ed.develop.lightning.force.com\"\nassert \"@\" in SF_USER, \"Username should be email-format (Salesforce convention)\"\nassert len(SF_PASS) >= 8, \"Password seems too short\"\n\nupsert_secret(SECRET_SF_URL,  SF_URL)\nupsert_secret(SECRET_SF_USER, SF_USER)\nupsert_secret(SECRET_SF_PASS, SF_PASS)\n\nprint(\"\\nAll three Salesforce secrets stored. Clear this cell's output if you want.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 10. Artifact Registry\n\nSingle Docker repo for all three images."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "existing = sh(f\"gcloud artifacts repositories list --location={INFRA_REGION} \"\n              f\"--filter=name~/{ARTIFACT_REPO}$ --format=value(name)\", check=False)\nif ARTIFACT_REPO not in existing:\n    sh(f\"gcloud artifacts repositories create {ARTIFACT_REPO} \"\n       f\"--repository-format=docker --location={INFRA_REGION} \"\n       f\"--description='Deal Desk Agent images' --project={PROJECT_ID}\")\n    print(f\"  Created repo: {ARTIFACT_REPO}\")\nelse:\n    print(f\"  Repo already exists: {ARTIFACT_REPO}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 11. Build container images via Cloud Build\n\nThree images, sequential, ~5 min each. Cloud Build replaces local `docker build` since Colab Enterprise runtimes have no Docker daemon.\n\nIf a build fails midway, re-run only that cell \u2014 Cloud Build is idempotent."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 11.1 Backend (FastAPI on Cloud Run)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "sh(f\"cd {DEMO_DIR}/backend && gcloud builds submit \"\n   f\"--tag={BACKEND_IMAGE} --region={INFRA_REGION} --project={PROJECT_ID} --quiet\",\n   capture=False)\nprint(\"\\nBackend image built.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 11.2 Frontend (React/Vite on Cloud Run, runtime config injection)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "sh(f\"cd {DEMO_DIR}/frontend && gcloud builds submit \"\n   f\"--tag={FRONTEND_IMAGE} --region={INFRA_REGION} --project={PROJECT_ID} --quiet\",\n   capture=False)\nprint(\"\\nFrontend image built.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 11.3 Computer Use VM (Ubuntu + Xvfb + Chrome + noVNC + agent server)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "sh(f\"cd {DEMO_DIR}/computer-use && gcloud builds submit \"\n   f\"--tag={BROWSER_IMAGE} --region={INFRA_REGION} --project={PROJECT_ID} --quiet\",\n   capture=False)\nprint(\"\\nComputer Use VM image built.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 12. Deploy the browser VM (GCE)\n\n### 12.1 Reserve a static external IP"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "existing = sh(f\"gcloud compute addresses list --regions={INFRA_REGION} \"\n              f\"--filter=name:{GCE_STATIC_IP} --format=value(name)\", check=False)\nif GCE_STATIC_IP not in existing:\n    sh(f\"gcloud compute addresses create {GCE_STATIC_IP} --region={INFRA_REGION} --project={PROJECT_ID}\")\n\nVM_STATIC_IP = sh(f\"gcloud compute addresses describe {GCE_STATIC_IP} \"\n                  f\"--region={INFRA_REGION} --format=value(address) --project={PROJECT_ID}\")\nprint(f\"Static IP: {VM_STATIC_IP}\")\n\n# Derived URLs\nNOVNC_URL_VAL  = f\"http://{VM_STATIC_IP}:6080/vnc.html?autoconnect=true&resize=scale\"\nBROWSER_AGENT_URL = f\"http://{VM_STATIC_IP}:8090\"\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 12.2 Firewall rules\n\nTwo rules:\n- `allow-novnc-{PROJECT_ID}` \u2014 tcp:6080 restricted to **your operator IP only** (no app-layer auth on noVNC)\n- `allow-agent-api-{PROJECT_ID}` \u2014 tcp:8090 open to 0.0.0.0/0 because Cloud Run's egress IPs are dynamic; the API is gated by `X-Agent-Secret`"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "NOVNC_RULE = f\"allow-novnc-{PROJECT_ID[:25]}\"\nAGENT_RULE = f\"allow-agent-api-{PROJECT_ID[:23]}\"\n\n# noVNC \u2014 operator IP only\nsh(f\"gcloud compute firewall-rules describe {NOVNC_RULE} --project={PROJECT_ID}\", check=False)\nexisting = sh(f\"gcloud compute firewall-rules list --filter=name:{NOVNC_RULE} --format=value(name) --project={PROJECT_ID}\", check=False)\nif NOVNC_RULE not in existing:\n    sh(f\"gcloud compute firewall-rules create {NOVNC_RULE} \"\n       f\"--direction=INGRESS --action=ALLOW --rules=tcp:6080 \"\n       f\"--source-ranges={OPERATOR_PUBLIC_IP}/32 \"\n       f\"--target-tags=deal-desk-browser --project={PROJECT_ID}\")\n    print(f\"  Created firewall rule {NOVNC_RULE} (source: {OPERATOR_PUBLIC_IP}/32)\")\nelse:\n    print(f\"  Firewall rule {NOVNC_RULE} already exists\")\n\n# Agent API \u2014 open + header-gated\nexisting = sh(f\"gcloud compute firewall-rules list --filter=name:{AGENT_RULE} --format=value(name) --project={PROJECT_ID}\", check=False)\nif AGENT_RULE not in existing:\n    sh(f\"gcloud compute firewall-rules create {AGENT_RULE} \"\n       f\"--direction=INGRESS --action=ALLOW --rules=tcp:8090 \"\n       f\"--source-ranges=0.0.0.0/0 \"\n       f\"--target-tags=deal-desk-browser --project={PROJECT_ID}\")\n    print(f\"  Created firewall rule {AGENT_RULE} (source: 0.0.0.0/0, header-gated)\")\nelse:\n    print(f\"  Firewall rule {AGENT_RULE} already exists\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 12.3 Create the GCE instance with the container\n\nContainer is invoked with `AGENT_SECRET` and `SALESFORCE_URL` injected from Secret Manager via metadata. Wait for instance RUNNING + container healthy (~3-5 min)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import time\n\n# Pull the salesforce URL we just stored \u2014 needed at container start so Chrome lands on the login page\nSF_URL_VAL = sh(f\"gcloud secrets versions access latest --secret={SECRET_SF_URL} --project={PROJECT_ID}\")\n\n# Idempotent create \u2014 delete first if it exists to apply latest config\nexisting = sh(f\"gcloud compute instances list --zones={GCE_ZONE} \"\n              f\"--filter=name:{GCE_INSTANCE} --format=value(name)\", check=False)\nif GCE_INSTANCE in existing:\n    print(f\"  Instance {GCE_INSTANCE} exists \u2014 deleting to redeploy with current config...\")\n    sh(f\"gcloud compute instances delete {GCE_INSTANCE} --zone={GCE_ZONE} \"\n       f\"--quiet --project={PROJECT_ID}\")\n\nsh(f\"gcloud compute instances create-with-container {GCE_INSTANCE} \"\n   f\"--zone={GCE_ZONE} --machine-type={GCE_MACHINE_TYPE} \"\n   f\"--container-image={BROWSER_IMAGE} \"\n   f\"--container-env=AGENT_SECRET={AGENT_SECRET_VALUE},SALESFORCE_URL={SF_URL_VAL},PROJECT_ID={PROJECT_ID},REGION={MODEL_REGION},SONNET_MODEL={SONNET_MODEL} \"\n   f\"--tags=deal-desk-browser \"\n   f\"--address={VM_STATIC_IP} \"\n   f\"--service-account={SA_EMAIL} \"\n   f\"--scopes=cloud-platform \"\n   f\"--project={PROJECT_ID}\", capture=False)\n\nprint(f\"\\nInstance created. Waiting for RUNNING state...\")\nfor _ in range(60):\n    status = sh(f\"gcloud compute instances describe {GCE_INSTANCE} --zone={GCE_ZONE} \"\n               f\"--format=value(status) --project={PROJECT_ID}\", check=False)\n    if status == \"RUNNING\":\n        print(f\"  Instance is RUNNING\")\n        break\n    time.sleep(5)\nelse:\n    raise RuntimeError(f\"Instance never reached RUNNING; last status: {status}\")\n\n# Now wait for container/agent server to come up \u2014 Chrome+Xvfb startup takes ~60-90s\nprint(\"\\nWaiting for agent server health endpoint to respond (~90s)...\")\nimport urllib.request, urllib.error\nfor i in range(36):\n    try:\n        with urllib.request.urlopen(f\"{BROWSER_AGENT_URL}/health\", timeout=3) as r:\n            if r.status == 200:\n                print(f\"  Agent server is healthy: {BROWSER_AGENT_URL}/health\")\n                break\n    except (urllib.error.URLError, urllib.error.HTTPError, ConnectionError):\n        pass\n    time.sleep(5)\nelse:\n    print(f\"  WARNING: agent server didn't respond within 3 minutes. Check logs:\")\n    print(f\"    gcloud compute instances get-serial-port-output {GCE_INSTANCE} --zone={GCE_ZONE}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 13. Deploy backend to Cloud Run\n\n`AGENT_SECRET` injected from Secret Manager (best practice \u2014 even though we have it in memory, the deploy command should reference Secret Manager so secret rotation works without notebook re-runs)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Allow the backend SA to read the AGENT_SECRET (already granted secretAccessor at project level, but tighten just in case)\nsh(f\"gcloud secrets add-iam-policy-binding {SECRET_AGENT} \"\n   f\"--member=serviceAccount:{SA_EMAIL} --role=roles/secretmanager.secretAccessor \"\n   f\"--project={PROJECT_ID} --quiet\", check=False)\n\nenv_vars = \",\".join([\n    f\"PROJECT_ID={PROJECT_ID}\",\n    f\"REGION={MODEL_REGION}\",\n    f\"BQ_DATASET={BQ_DATASET}\",\n    f\"MODEL_PROVIDER=claude\",\n    f\"OPUS_MODEL={OPUS_MODEL}\",\n    f\"SONNET_MODEL={SONNET_MODEL}\",\n    f\"HAIKU_MODEL={HAIKU_MODEL}\",\n    f\"BROWSER_AGENT_URL={BROWSER_AGENT_URL}\",\n])\n\nsh(f\"gcloud run deploy {BACKEND_SERVICE} \"\n   f\"--image={BACKEND_IMAGE} --region={INFRA_REGION} \"\n   f\"--service-account={SA_EMAIL} \"\n   f\"--set-env-vars={env_vars} \"\n   f\"--set-secrets=AGENT_SECRET={SECRET_AGENT}:latest \"\n   f\"--memory=2Gi --cpu=2 --timeout=300 --max-instances=5 \"\n   f\"--allow-unauthenticated --quiet --project={PROJECT_ID}\", capture=False)\n\nBACKEND_URL = sh(f\"gcloud run services describe {BACKEND_SERVICE} \"\n                 f\"--region={INFRA_REGION} --format=value(status.url) --project={PROJECT_ID}\")\nprint(f\"\\nBackend URL: {BACKEND_URL}\")\n\n# Now redeploy with A2A_AGENT_URL set to the actual URL we just received,\n# so the /.well-known/agent.json card returns a stable URL for Gemini Enterprise registration.\nprint(\"\\nRedeploying backend with A2A_AGENT_URL set (so the agent card is stable)...\")\nenv_vars_with_a2a = env_vars + f\",A2A_AGENT_URL={BACKEND_URL}\"\nsh(f\"gcloud run services update {BACKEND_SERVICE} \"\n   f\"--region={INFRA_REGION} \"\n   f\"--update-env-vars=A2A_AGENT_URL={BACKEND_URL} \"\n   f\"--project={PROJECT_ID} --quiet\", capture=False)\nprint(f\"A2A_AGENT_URL set to {BACKEND_URL}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 14. Deploy frontend to Cloud Run\n\nUses the runtime-injection pattern \u2014 `API_BASE` and `NOVNC_URL` set at deploy time, no rebuild."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "sh(f\"gcloud run deploy {FRONTEND_SERVICE} \"\n   f\"--image={FRONTEND_IMAGE} --region={INFRA_REGION} \"\n   f\"--set-env-vars=API_BASE={BACKEND_URL},NOVNC_URL={NOVNC_URL_VAL} \"\n   f\"--memory=512Mi --cpu=1 --max-instances=3 \"\n   f\"--allow-unauthenticated --quiet --project={PROJECT_ID}\", capture=False)\n\nFRONTEND_URL = sh(f\"gcloud run services describe {FRONTEND_SERVICE} \"\n                  f\"--region={INFRA_REGION} --format=value(status.url) --project={PROJECT_ID}\")\nprint(f\"\\nFrontend URL: {FRONTEND_URL}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 15. Salesforce one-time login (human-in-the-loop)\n\nThe browser VM's Chrome session opened to your Salesforce login page when the container started. The Computer Use agent CAN type credentials, but the cleanest demo flow is to log in once yourself, then let Computer Use pick up the authenticated session.\n\n**Open the noVNC URL printed below in a new browser tab**, log in with the Salesforce username + password from \u00a71.3 / \u00a79.2, navigate to the Sales app if prompted, then come back and run the next cell."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "print(\"Open this in a new browser tab:\")\nprint(f\"  {NOVNC_URL_VAL}\")\nprint()\nprint(\"Steps inside noVNC:\")\nprint(\"  1. Wait for the Salesforce login page to load\")\nprint(\"  2. Enter your Salesforce username (email-format login)\")\nprint(\"  3. Enter your password\")\nprint(\"  4. If prompted, accept the browser device verification (one-time)\")\nprint(\"  5. Land on the Sales app home page\")\nprint(\"  6. Come back here and run the next cell\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "_ = input(\"Press Enter once you are logged into Salesforce in the noVNC tab... \")\nprint(\"OK \u2014 Computer Use can now drive the authenticated session.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 16. Smoke tests\n\nThree quick checks confirming end-to-end wiring."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 16.1 Backend health"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import urllib.request\nwith urllib.request.urlopen(f\"{BACKEND_URL}/api/health\", timeout=10) as r:\n    body = r.read().decode()\nprint(f\"  /api/health -> {r.status}: {body[:200]}\")\nassert r.status == 200, \"Backend /api/health did not return 200\"\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 16.2 Browser VM agent server health"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "with urllib.request.urlopen(f\"{BROWSER_AGENT_URL}/health\", timeout=10) as r:\n    body = r.read().decode()\nprint(f\"  agent /health -> {r.status}: {body[:200]}\")\nassert r.status == 200, \"Browser VM /health did not return 200\"\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 16.3 Agent card (A2A discovery)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "with urllib.request.urlopen(f\"{BACKEND_URL}/.well-known/agent.json\", timeout=10) as r:\n    card = json.loads(r.read())\nprint(json.dumps(card, indent=2))\nassert card[\"url\"] == BACKEND_URL, (\n    f\"A2A card URL ({card['url']}) does not match BACKEND_URL ({BACKEND_URL}). \"\n    \"The \u00a713 redeploy should have set A2A_AGENT_URL \u2014 check Cloud Run env vars.\"\n)\nprint(f\"\\n[OK] A2A card URL matches deploy URL \u2014 safe to register with Gemini Enterprise.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 17. Deploy to Vertex AI Agent Engine\n\nWraps the ADK pipeline as an `AdkApp` and deploys it as a managed Agent Engine. Takes ~5\u201310 minutes. The deployed Agent Engine resource name is captured in `AGENT_ENGINE_RESOURCE` and reused in \u00a718 when registering with Gemini Enterprise.\n\nThe repo's `deploy/agent_engine_deploy.py` hardcodes a project ID \u2014 we set the env vars first then patch in our project so the script is reusable."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import sys\n\n# Create staging bucket if it doesn't exist\ntry:\n    sh(f\"gcloud storage buckets describe {STAGING_BUCKET} --project={PROJECT_ID}\", check=False)\n    bucket_exists = sh(f\"gcloud storage buckets list --filter=name:{STAGING_BUCKET[5:]} \"\n                       f\"--format=value(name) --project={PROJECT_ID}\", check=False)\n    if not bucket_exists:\n        sh(f\"gcloud storage buckets create {STAGING_BUCKET} --location={INFRA_REGION} --project={PROJECT_ID}\")\n        print(f\"  Created staging bucket: {STAGING_BUCKET}\")\n    else:\n        print(f\"  Staging bucket exists: {STAGING_BUCKET}\")\nexcept Exception as e:\n    print(f\"  Bucket setup error (continuing): {e}\")\n\n# Set env vars expected by agent_deploy/agent.py \u2014 these override the os.environ.setdefault() calls in that file\nos.environ[\"GOOGLE_CLOUD_PROJECT\"]  = PROJECT_ID\nos.environ[\"GOOGLE_CLOUD_LOCATION\"] = MODEL_REGION\nos.environ[\"PROJECT_ID\"] = PROJECT_ID\nos.environ[\"REGION\"]     = MODEL_REGION\nos.environ[\"BQ_DATASET\"] = BQ_DATASET\nos.environ[\"MODEL_PROVIDER\"] = \"claude\"\nos.environ[\"OPUS_MODEL\"]   = OPUS_MODEL\nos.environ[\"SONNET_MODEL\"] = SONNET_MODEL\nos.environ[\"HAIKU_MODEL\"]  = HAIKU_MODEL\nos.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"\n# Needed by agent_deploy/tools.py trigger_salesforce_opportunity (parameterized in PR #3)\nos.environ[\"BACKEND_URL\"] = BACKEND_URL\nos.environ[\"NOVNC_URL\"]   = NOVNC_URL_VAL\n\n# Make the demo's agent_deploy package importable\nsys.path.insert(0, DEMO_DIR)\n\n# Re-import in case a prior cell already imported with stale env\nimport importlib\nif \"agent_deploy\" in sys.modules:\n    importlib.reload(sys.modules[\"agent_deploy\"])\n\nfrom agent_deploy.agent import root_agent  # noqa: E402\nimport vertexai\nfrom vertexai import agent_engines\n\nvertexai.init(project=PROJECT_ID, location=AGENT_ENGINE_LOCATION, staging_bucket=STAGING_BUCKET)\n\nprint(\"Wrapping ADK agent in AdkApp...\")\napp = agent_engines.AdkApp(agent=root_agent, enable_tracing=True)\n\n# Quick local smoke\nprint(\"Local smoke test (1 message)...\")\ntry:\n    list(app.stream_query(user_id=\"notebook-smoke\", message=\"hello\"))\n    print(\"  Local stream_query succeeded.\")\nexcept Exception as e:\n    print(f\"  Local smoke produced exception (often OK for streaming): {type(e).__name__}: {e}\")\n\nprint(\"\\nDeploying to Agent Engine (5-10 min) ...\")\nclient = vertexai.Client(project=PROJECT_ID, location=AGENT_ENGINE_LOCATION)\nremote_agent = client.agent_engines.create(\n    agent=app,\n    config={\n        \"requirements\": [\n            \"cloudpickle>=3.0.0\",\n            \"pydantic>=2.0.0\",\n            \"google-cloud-aiplatform[agent_engines,adk]\",\n            \"google-adk>=1.2.0\",\n            \"anthropic[vertex]>=0.43.0\",\n            \"google-cloud-bigquery>=3.27.0\",\n            \"httpx>=0.27.0\",\n        ],\n        \"staging_bucket\": STAGING_BUCKET,\n        \"display_name\": \"Deal Desk Agent\",\n        \"description\": \"FSI Deal Desk pipeline \u2014 Claude on Vertex AI + ADK\",\n        \"service_account\": SA_EMAIL,\n        \"env_vars\": {\n            \"GOOGLE_CLOUD_PROJECT\": PROJECT_ID,\n            \"PROJECT_ID\":  PROJECT_ID,\n            \"REGION\":      MODEL_REGION,\n            \"BQ_DATASET\":  BQ_DATASET,\n            \"OPUS_MODEL\":  OPUS_MODEL,\n            \"SONNET_MODEL\": SONNET_MODEL,\n            \"HAIKU_MODEL\": HAIKU_MODEL,\n            \"BACKEND_URL\": BACKEND_URL,\n            \"NOVNC_URL\":   NOVNC_URL_VAL,\n        },\n    },\n)\n\nAGENT_ENGINE_RESOURCE = str(remote_agent.api_resource)\nprint(f\"\\n[OK] Agent Engine deployed.\")\nprint(f\"  Resource name: {AGENT_ENGINE_RESOURCE}\")\nprint()\nprint(f\"  Save this for the Gemini Enterprise registration in \u00a718:\")\nprint(f\"  AGENT_ENGINE_RESOURCE = \\\"{AGENT_ENGINE_RESOURCE}\\\"\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 18. Register agent with Gemini Enterprise\n\nAdds the deployed agent to your Gemini Enterprise engine so end-users can discover and invoke it from the Gemini Enterprise UI.\n\nWe register **two** integration paths so the agent works whichever way Gemini Enterprise wants to call it:\n\n1. **A2A endpoint** \u2014 the public Cloud Run backend URL serving `/.well-known/agent.json` (the path Gemini Enterprise uses for streaming, multi-turn conversations)\n2. **Agent Engine resource** \u2014 the Vertex AI Agent Engine resource captured in \u00a717 (used when Gemini Enterprise prefers managed-runtime execution)\n\n### 18.1 Confirm the engine ID and where to use the registered agent later"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "print(f\"Registering into Gemini Enterprise engine:\")\nprint(f\"  Project:     {PROJECT_ID}\")\nprint(f\"  Location:    {DISCOVERY_ENGINE_LOCATION}\")\nprint(f\"  Engine ID:   {GEMINI_ENTERPRISE_ENGINE_ID}\")\nprint()\nprint(f\"After registration completes, your end-users will find the agent at:\")\nprint(f\"  https://console.cloud.google.com/gen-app-builder/engines/{GEMINI_ENTERPRISE_ENGINE_ID}/agents?project={PROJECT_ID}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 18.2 Register the A2A endpoint\n\nPosts the agent definition to the Discovery Engine `agents` collection on your engine. The agent card content from `/.well-known/agent.json` is included so Gemini Enterprise has the schema for skills, capabilities, and the deployed Agent Engine resource."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import httpx\ncreds.refresh(google.auth.transport.requests.Request())\ntoken = creds.token\n\n# Pull the live agent card\nwith urllib.request.urlopen(f\"{BACKEND_URL}/.well-known/agent.json\", timeout=10) as r:\n    live_card = json.loads(r.read())\n\n# Build the registration payload. The Discovery Engine `agents.create` shape:\n#   POST .../engines/{engine}/assistants/default_assistant/agents\n# Each agent is identified by an `agent_id` you choose.\nparent = (\n    f\"projects/{PROJECT_ID}/locations/{DISCOVERY_ENGINE_LOCATION}\"\n    f\"/collections/default_collection/engines/{GEMINI_ENTERPRISE_ENGINE_ID}\"\n    f\"/assistants/default_assistant\"\n)\nagent_id = \"deal-desk-agent\"\n\nagent_resource = {\n    \"displayName\": \"FSI Deal Desk Agent\",\n    \"description\": live_card[\"description\"],\n    \"icon\": {\n        \"uri\": \"https://www.gstatic.com/images/icons/material/system/2x/business_center_black_48dp.png\"\n    },\n    # A2A endpoint\n    \"a2aAgentDefinition\": {\n        \"jsonAgentCard\": json.dumps(live_card),\n    },\n    # Vertex AI Agent Engine link \u2014 captured in \u00a717\n    \"managedAgentDefinition\": {\n        \"agentEngineRuntime\": {\n            \"agentEngine\": AGENT_ENGINE_RESOURCE,\n        },\n    },\n}\n\nurl = (\n    f\"https://discoveryengine.googleapis.com/v1alpha/{parent}/agents\"\n    f\"?agentId={agent_id}\"\n)\n\nresp = httpx.post(\n    url,\n    headers={\"Authorization\": f\"Bearer {token}\", \"Content-Type\": \"application/json\"},\n    json=agent_resource,\n    timeout=30,\n)\n\nif resp.status_code == 200:\n    print(f\"[OK] Agent registered.\")\n    print(json.dumps(resp.json(), indent=2)[:1500])\nelif resp.status_code == 409:\n    # Already exists \u2014 patch it instead\n    print(\"Agent already exists \u2014 updating in place...\")\n    patch_url = f\"https://discoveryengine.googleapis.com/v1alpha/{parent}/agents/{agent_id}\"\n    resp = httpx.patch(\n        patch_url,\n        headers={\"Authorization\": f\"Bearer {token}\", \"Content-Type\": \"application/json\"},\n        json=agent_resource,\n        timeout=30,\n    )\n    print(f\"  PATCH status: {resp.status_code}\")\n    print(json.dumps(resp.json(), indent=2)[:1500])\nelse:\n    print(f\"[WARN] Registration returned {resp.status_code}\")\n    print(resp.text[:1500])\n    print()\n    print(\"If this is your first time using the v1alpha agents API, the resource \"\n          \"shape may have changed. Check the latest spec at \"\n          \"https://cloud.google.com/agentspace/docs/reference/rest\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 18.3 Verify discoverability"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "list_url = f\"https://discoveryengine.googleapis.com/v1alpha/{parent}/agents\"\nresp = httpx.get(list_url, headers={\"Authorization\": f\"Bearer {token}\"}, timeout=15)\nagents_list = resp.json().get(\"agents\", [])\nprint(f\"Engine {GEMINI_ENTERPRISE_ENGINE_ID} has {len(agents_list)} registered agent(s):\")\nfor a in agents_list:\n    print(f\"  - {a.get('displayName')}  ({a.get('name')})\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 19. Deployment summary\n\nEverything is up. Bookmark these."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import Markdown\nMarkdown(f\"\"\"\n### Live URLs\n\n| Resource | URL |\n|---|---|\n| **Frontend** (the demo UI) | {FRONTEND_URL} |\n| **Backend** (FastAPI on Cloud Run) | {BACKEND_URL} |\n| **Backend health** | {BACKEND_URL}/api/health |\n| **A2A agent card** | {BACKEND_URL}/.well-known/agent.json |\n| **noVNC** (browser VM live view) | {NOVNC_URL_VAL} |\n| **Agent Engine resource** | `{AGENT_ENGINE_RESOURCE}` |\n| **Gemini Enterprise discovery** | https://console.cloud.google.com/gen-app-builder/engines/{GEMINI_ENTERPRISE_ENGINE_ID}/agents?project={PROJECT_ID} |\n\n### Try it\n\n- **From the demo frontend** \u2014 open the Frontend URL above, pick a preset prompt, watch the multi-agent pipeline run\n- **From Gemini Enterprise** \u2014 open your engine's chat surface and ask \"Onboard new client: [name]. $250M AUM, long/short equity\"\n- **Direct A2A call** \u2014 POST to the backend root with `{{\"jsonrpc\":\"2.0\",\"method\":\"message/send\",\"params\":{{...}}}}`\n- **Watch Salesforce automation live** \u2014 keep the noVNC tab open during a deal-pipeline run; the Salesforce agent will drive it\n\n### When you're done, run \u00a720 (teardown) to stop billing.\n\"\"\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 20. Teardown \u2014 stop billing\n\n> **Important:** the GCE browser VM bills 24/7. Run these cells when you're done with the demo to avoid surprise charges.\n\nEach cell deletes one resource type. They can be run in any order."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 20.1 Delete GCE instance + static IP + firewall rules"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "sh(f\"gcloud compute instances delete {GCE_INSTANCE} --zone={GCE_ZONE} --quiet --project={PROJECT_ID}\", check=False)\nsh(f\"gcloud compute addresses delete {GCE_STATIC_IP} --region={INFRA_REGION} --quiet --project={PROJECT_ID}\", check=False)\nsh(f\"gcloud compute firewall-rules delete {NOVNC_RULE} --quiet --project={PROJECT_ID}\", check=False)\nsh(f\"gcloud compute firewall-rules delete {AGENT_RULE} --quiet --project={PROJECT_ID}\", check=False)\nprint(\"GCE + firewall resources deleted.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 20.2 Delete Cloud Run services"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "sh(f\"gcloud run services delete {BACKEND_SERVICE} --region={INFRA_REGION} --quiet --project={PROJECT_ID}\", check=False)\nsh(f\"gcloud run services delete {FRONTEND_SERVICE} --region={INFRA_REGION} --quiet --project={PROJECT_ID}\", check=False)\nprint(\"Cloud Run services deleted.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 20.3 Delete Agent Engine deployment + Gemini Enterprise registration"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Unregister from Gemini Enterprise\ndel_url = f\"https://discoveryengine.googleapis.com/v1alpha/{parent}/agents/deal-desk-agent\"\nresp = httpx.delete(del_url, headers={\"Authorization\": f\"Bearer {token}\"}, timeout=15)\nprint(f\"  Gemini Enterprise unregister: HTTP {resp.status_code}\")\n\n# Delete Agent Engine deployment\ntry:\n    client.agent_engines.delete(name=AGENT_ENGINE_RESOURCE, force=True)\n    print(f\"  Agent Engine deleted: {AGENT_ENGINE_RESOURCE}\")\nexcept Exception as e:\n    print(f\"  Agent Engine delete failed (may already be gone): {e}\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### 20.4 Delete Artifact Registry images, BigQuery dataset, secrets, service account, staging bucket\n\nMost expensive resources are gone after \u00a720.1\u201320.3. The rest is housekeeping. Skip if you want to redeploy soon (these are reusable)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Artifact Registry repo (deletes all images)\nsh(f\"gcloud artifacts repositories delete {ARTIFACT_REPO} --location={INFRA_REGION} --quiet --project={PROJECT_ID}\", check=False)\n\n# BigQuery dataset\nsh(f\"bq rm -r -f --dataset {PROJECT_ID}:{BQ_DATASET}\", check=False)\n\n# Secrets\nfor s in [SECRET_AGENT, SECRET_SF_URL, SECRET_SF_USER, SECRET_SF_PASS]:\n    sh(f\"gcloud secrets delete {s} --quiet --project={PROJECT_ID}\", check=False)\n\n# Staging bucket (recursively)\nsh(f\"gcloud storage rm -r {STAGING_BUCKET} --quiet --project={PROJECT_ID}\", check=False)\n\n# Service account\nsh(f\"gcloud iam service-accounts delete {SA_EMAIL} --quiet --project={PROJECT_ID}\", check=False)\n\nprint(\"\\nAll Deal Desk resources deleted. APIs left enabled (no cost).\")\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

A Colab Enterprise deploy notebook for the Deal Desk Agent demo. Run cell-by-cell in a fresh GCP project to stand up the entire system end-to-end — BigQuery + seed data, Cloud Run backend/frontend, GCE browser VM, Agent Engine, and Gemini Enterprise registration — in 25-40 minutes.

Lives at **`05-solution-accelerators/deal-desk-agent-deploy/colab_deploy.ipynb`** (72 cells, 38 markdown + 34 code).

## What's in the notebook

- **§1 Prerequisites** — explicit, including step-by-step Salesforce Developer Edition signup with the field gotchas (username must be email-format, don't enable MFA), Vertex Claude Model Garden enablement, and how to find your existing Gemini Enterprise engine ID
- **§2 Configuration** — single cell where the user sets `PROJECT_ID` and `GEMINI_ENTERPRISE_ENGINE_ID`. All later cells derive from these.
- **§3 Preflight** — fail-fast checks for billing, project alignment, ADC, Vertex Claude model access (1-token rawPredict against each of the three models), and operator IP. The most common silent failure (no Model Garden grant) is caught here, not at deploy time.
- **§4-6 APIs, pinned tooling, repo clone**
- **§7 BigQuery** — dataset, schemas derived from `backend/tools/bigquery_tools.py`, and **20 synthetic FSI clients** (hedge funds, pension funds, family offices, sovereign wealth, RIAs) with matching market intelligence and compliance records. Deterministic seed for reproducibility. Idempotent — re-running truncates and reloads.
- **§8-9 IAM + Secrets** — service account, role bindings, AGENT_SECRET generated and stored in Secret Manager, Salesforce credentials prompted via `getpass`
- **§10-11 Artifact Registry + Cloud Build** for all three images
- **§12 GCE browser VM** — static IP, firewall rules (noVNC restricted to operator IP, agent API open + header-gated as designed), n2-standard-4 (upgraded from e2-standard-4 for Chrome + Computer Use), waits for instance RUNNING and agent server `/health`
- **§13-14 Cloud Run** for backend + frontend. Backend redeployed with `A2A_AGENT_URL` set to the live URL so the agent card is stable for Gemini Enterprise registration. Frontend uses the runtime config injection added in PR #3 — `API_BASE` and `NOVNC_URL` set via env vars, no rebuild on redeploy.
- **§15 Salesforce one-time login** — human-in-the-loop via noVNC. Markdown cell shows the URL, code cell waits for the user to confirm.
- **§16 Smoke tests** — backend `/api/health`, browser VM `/health`, A2A card resolves to the deploy URL (asserts the §13 redeploy worked)
- **§17 Agent Engine deploy** — wraps the ADK `root_agent` as `AdkApp`, deploys with all env vars threaded through, **captures the Agent Engine resource name** in `AGENT_ENGINE_RESOURCE` and prints it for §18
- **§18 Gemini Enterprise registration** — calls Discovery Engine API to register the agent in the user's existing engine. Registers BOTH integration paths so the agent works whichever way Gemini Enterprise wants to invoke it:
  - `a2aAgentDefinition` — A2A endpoint with the live agent card
  - `managedAgentDefinition.agentEngineRuntime.agentEngine` — the resource captured in §17
  Includes verify cell (lists agents on the engine) and 409-handling (PATCH instead of POST if already registered).
- **§19 Summary** — rendered table of all live URLs, the Agent Engine resource ID, and a deep-link to the Gemini Enterprise console for the registered agent
- **§20 Teardown** — every billable resource. Includes Gemini Enterprise unregistration via DELETE.

## Also patched

`03-demos/deal-desk-agent/deploy/agent_engine_deploy.py` — the standalone deploy script still hardcoded the original demo's project ID, region, and staging bucket. Now reads from `GOOGLE_CLOUD_PROJECT`/`PROJECT_ID`, `AGENT_ENGINE_LOCATION`, `STAGING_BUCKET`, and `AGENT_SERVICE_ACCOUNT` env vars with sensible defaults. Same parameterization theme as #2 and #3 — so anyone running this script outside the notebook can target their own project.

## Test plan

- [ ] Open `05-solution-accelerators/deal-desk-agent-deploy/colab_deploy.ipynb` in Colab Enterprise — confirm cells render correctly
- [ ] Read §1 and §3 — confirm prereqs and preflight checks are clear and complete
- [ ] Read §17-18 — confirm the Agent Engine resource ID is captured and reused in the Gemini Enterprise registration
- [ ] Confirm `03-demos/deal-desk-agent/deploy/agent_engine_deploy.py` raises a clear error when `GOOGLE_CLOUD_PROJECT` is unset, and uses sensible defaults otherwise